### PR TITLE
Update the README for use in public

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,13 +1,19 @@
 Contributing
 ============
 
-1.  **Please sign one of the contributor license agreements [below][6].**
-1.  [File an issue][9] to notify the maintainers about what you're working on.
-1.  [Fork the repo][10], develop and [test][11] your code changes, add docs.
-1.  Make sure that your commit messages clearly describe the changes.
-1.  [Send][12] a pull request.
+Here are some guidelines for hacking on `artman`_.
 
-Here are some guidelines for hacking on `artman`.
+-  Please **sign** one of the `Contributor License Agreements`_ below.
+-  `File an issue`_ to notify the maintainers about what you're working on.
+-  `Fork the repo`_; develop and `test your code changes`_; add docs.
+-  Make sure that your `commit messages`_ clearly describe the changes.
+-  `Make the pull request`_.
+
+.. _`Fork the repo`: https://help.github.com/articles/fork-a-repo
+.. _`forking`: https://help.github.com/articles/fork-a-repo
+.. _`commit messages`: http://chris.beams.io/posts/git-commit/
+
+.. _`File an issue`:
 
 Before writing code, file an issue
 ----------------------------------
@@ -20,21 +26,26 @@ used to hash that all out.
 Fork `artman`
 -------------
 
-We will use GitHub's mechanism for [forking][8] repositories and making pull
+We will use GitHub's mechanism for `forking`_ repositories and making pull
 requests. Fork the repository, and make your changes in the forked repository.
+
+.. _`test your code changes`:
 
 Include tests
 -------------
 
-Be sure to add the relevant tests before making the pull request. Docs will be
-updated automatically when we merge to `master`, but you should also build
-the docs yourself via `tox -e docs` and make sure they're readable.
+Be sure to add relevant tests and run then them using :code:`tox` before making the pull request.
+Docs will be updated automatically when we merge to `master`, but
+you should also build the docs yourself via :code:`tox -e docs`, making sure that the docs build OK
+and that they are readable.
+
+.. _`tox`: https://tox.readthedocs.org/en/latest/
 
 Make the pull request
 ---------------------
 
-Once you have made all your changes, tests, and updated the documentation,
-make a pull request to move everything back into the main `artman`
+Once you have made all your changes, tested, and updated the documentation,
+make a pull request to move everything back into the main `artman`_
 repository. Be sure to reference the original issue in the pull request.
 Expect some back-and-forth with regards to style and compliance of these
 rules.
@@ -43,88 +54,70 @@ Using a Development Checkout
 ----------------------------
 
 You’ll have to create a development environment to hack on
-`artman`, using a Git checkout:
+`artman`_, using a Git checkout:
 
--   While logged into your GitHub account, navigate to the `artman`
-    [repo][1] on GitHub.
+-   While logged into your GitHub account, navigate to the `artman repo`_ on GitHub.
 -   Fork and clone the `artman` repository to your GitHub account
     by clicking the "Fork" button.
 -   Clone your fork of `artman` from your GitHub account to your
     local computer, substituting your account username and specifying
     the destination as `hack-on-artman`. For example:
 
-    ```bash
-    $ cd ${HOME}
-    $ git clone git@github.com:USERNAME/artman.git hack-on-artman
-    $ cd hack-on-artman
-    $ # Configure remotes such that you can pull changes from the artman
-    $ # repository into your local repository.
-    $ git remote add upstream https://github.com:googleapis/artman
-    $ # fetch and merge changes from upstream into master
-    $ git fetch upstream
-    $ git merge upstream/master
-    ```
+  .. code:: bash
+
+    cd ${HOME}
+    git clone git@github.com:USERNAME/artman.git hack-on-artman
+    cd hack-on-artman
+
+    # Configure remotes such that you can pull changes from the artman
+    # repository into your local repository.
+    git remote add upstream https://github.com:google/artman
+
+    # fetch and merge changes from upstream into master
+    git fetch upstream
+    git merge upstream/master
+
 
 Now your local repo is set up such that you will push changes to your
 GitHub repo, from which you can submit a pull request.
 
--   Create a virtualenv in which to install `artman`:
+-   Create use tox to create development virtualenv in which `artman`_ is installed:
 
-    ```bash
-    $ cd ~/hack-on-artman
-    $ virtualenv -ppython2.7 env
-    ```
+  .. code:: bash
 
-    Note that very old versions of virtualenv (virtualenv versions
-    below, say, 1.10 or thereabouts) require you to pass a
-    `--no-site-packages` flag to get a completely isolated environment.
+    sudo pip install tox
+    cd ~/hack-on-artman
+    tox -e devenv
 
-    You can choose which Python version you want to use by passing a
-    `-p` flag to `virtualenv`. For example, `virtualenv -ppython2.7`
-    chooses the Python 2.7 interpreter to be installed.
+-   This is creates a tox virtualenv named `development` that has artman installed.
+    Activate it to use artman locally, e.g, from the python prompt.
 
-    From here on in within these instructions, the
-    `~/hack-on-artman/env` virtual environment you created above will be
-    referred to as `$VENV`. To use the instructions in the steps that
-    follow literally, use the `export VENV=~/hack-on-artman/env`
-    command.
+  .. code:: bash
 
--   Install `artman` from the checkout into the virtualenv using
-    `setup.py develop`. Running `setup.py develop` **must** be done while
-    the current working directory is the `artman` checkout
-    directory:
+    cd ~/hack-on-artman
+    . ./tox/develop/bin/activate
 
-    ```bash
-    $ cd ~/hack-on-artman
-    $ $VENV/bin/python setup.py develop
-    ```
+.. _`artman`: https://github.com/googleapis/artman
+.. _`artman repo`: https://github.com/googleapis/artman
+
 
 Running Tests
---------------
-
--   To run all tests for `artman` on a single Python version, run
-    `tox` from your development virtualenv (See
-    **Using a Development Checkout** above).
+-------------
 
 -   To run the full set of `artman` tests on all platforms, install
-    [`tox`][2] into a system Python.  The `tox` console script will be
+    `tox`_ into a system Python.  The :code:`tox` console script will be
     installed into the scripts location for that Python.  While in the
-    `artman` checkout root directory (it contains `tox.ini`),
-    invoke the `tox` console script.  This will read the `tox.ini` file and
+    `artman` checkout root directory (it contains :code:`tox.ini`),
+    invoke the `tox` console script.  This will read the :code:`tox.ini` file and
     execute the tests on multiple Python versions and platforms; while it runs,
     it creates a virtualenv for each version/platform combination.  For
     example:
 
-    ```bash
-    $ sudo pip install tox
-    $ cd ~/hack-on-artman
-    $ tox
-    ```
+  .. code:: bash
 
--   In order to run the `pypy` environment (in `tox`) you'll need at
-    least version 2.6 of `pypy` installed. See the [docs][13] for
-    more information.
-
+      sudo pip install tox
+      cd ~/hack-on-artman
+      tox
 
 Contributor License Agreements
 ------------------------------
@@ -134,20 +127,12 @@ License Agreement (CLA):
 
 -   **If you are an individual writing original source code** and **you own
     the intellectual property**, then you'll need to sign an
-    [individual CLA][4].
+    `individual CLA`_.
 -   **If you work for a company that wants to allow you to contribute your
-    work**, then you'll need to sign a [corporate CLA][5].
+    work**, then you'll need to sign a `corporate CLA`_.
 
 You can sign these electronically (just scroll to the bottom). After that,
 we'll be able to accept your pull requests.
 
-[1]: https://github.com/google/oauth2client
-[2]: https://tox.readthedocs.org/en/latest/
-[4]: https://developers.google.com/open-source/cla/individual
-[5]: https://developers.google.com/open-source/cla/corporate
-[6]: #contributor-license-agreements
-[8]: https://help.github.com/articles/fork-a-repo/
-[9]: #before-writing-code-file-an-issue
-[10]: #fork-artman
-[11]: #include-tests
-[12]: #make-the-pull-request
+.. _`individual CLA`: https://developers.google.com/open-source/cla/individual
+.. _`corporate CLA`: https://developers.google.com/open-source/cla/corporate

--- a/README.rst
+++ b/README.rst
@@ -19,145 +19,20 @@ from the protobuf source IDL and additional configuration in yaml files.
 Installation
 ------------
 
-*N.B., at the moment, this library is under development, and has not been published to pypi*
+At the moment, this library is under development, so please see
+`using a development checkout`_ for installation instructions
 
-Clone this repository:
-
-  ::
-     $ git clone sso://gapi/pipeline
-     $ cd pipeline
-
-Install tox if it has not already been installed:
-
-  ::
-     $ sudo pip install tox  # done once, installed globally
-
-Create, then activate the tox development environment:
-
-  ::
-     $ tox -e devenv
-     $ . .tox/develop/bin/activate
-     $(develop) ...
-
-Once done developing, deactivate the development environment:
-
-  ::
-     $(develop) deactivate
-
-Install nvm if it has not already been installed:
-
-  ::
-     $ npm install -g nvm
-
-Install packman:
-
-  ::
-     $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | bash
-     $ nvm install 5.0
-     $ nvm use 5.0
-     $ npm install -g googleapis-packman
+.. _`using a development checkout`: https://github.com/googleapis/artman/blob/master/CONTRIBUTING.rst#using-a-development-checkout
 
 
-Try it out
-----------
+Usage
+-----
 
-To execute a build pipeline locally, try the following example command:
+Currently, this tool can only be run in the development environment of the
+development team, as some dependencies are yet to be published. See USAGE_ for
+details.
 
-::
-    $ python execute_pipeline.py --pipeline_kwargs={\'sleep_secs\':2} SamplePipeline
-
-To execute a build pipeline remotely, start two consoles and run the following command
-in one console:
-
-::
-    $ python start_conductor.py
-
-
-And then run the following command for multiple times with different parameter:
-
-::
-    $ python execute_pipeline.py --pipeline_kwargs={\'sleep_secs\':2} --remote_mode SamplePipeline
-
-
-Please note, there is no guarantee that your pipeline job will be claimed by the
-conductor running on your machine. It can also be picked up by other conductor
-processes. You can run the second command for multiple times, and chances are
-good that your conductor will pick up one job at least.
-
-To run the Python pipeline for logging:
-
-::
-    $ python execute_pipeline.py \
-        --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_python,\
-        ../googleapis/pipeline_config/pipeline_common.yaml:default|python" \
-        PythonGrpcClientPipeline
-
-    $ python execute_pipeline.py \
-        --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_python,\
-        ../googleapis/pipeline_config/pipeline_common.yaml:default|python" \
-        PythonVkitClientPipeline
-
-To run the Java pipeline:
-
-::
-    $ python execute_pipeline.py \
-        --config "../googleapis/pipeline_config/pipeline_core.yaml:core,\
-        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
-        JavaCorePipeline
-
-    $ python execute_pipeline.py \
-        --config "../googleapis/pipeline_config/pipeline_pubsub.yaml:pubsub_common|pubsub_java,\
-        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
-        JavaGrpcClientPipeline
-
-    $ python execute_pipeline.py \
-        --config "../googleapis/pipeline_config/pipeline_pubsub.yaml:pubsub_common|pubsub_java,\
-        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
-        JavaVkitClientPipeline
-
-To run the Go pipeline, first the core protos have to be compiled into the output directory.
-Note: this won't be necessary once a public repository for core proto pb.go files.
-
-::
-    $ python execute_pipeline.py \
-       --config "../googleapis/pipeline_config/pipeline_core.yaml:core,\
-       ../googleapis/pipeline_config/pipeline_logging.yaml:logging_go,\
-       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
-       GoCoreProtoPipeline
-
-The actual Go pipeline is as follows:
-
-::
-    $ python execute_pipeline.py \
-       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go|logging_type,\
-       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
-       GoCoreProtoPipeline
-
-    $ python execute_pipeline.py \
-       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go,\
-       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
-       GoGrpcClientPipeline
-
-    $ python execute_pipeline.py \
-       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go,\
-       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
-       GoVkitClientPipeline
-
-
-Pipeline config files
----------------------
-
-Pipeline config files contains configuration data to run pipeline tasks.
-
-googleapis/pipeline_config/pipeline_common.yaml
-
-- default: Default configuration for all pipelines
-- {language}: Language specific configuration
-
-googleapis/pipeline_config/pipeline_{API}.yaml
-
-- {API}_common: cross language API specific configuration
-- {API}_{language}: API x language configurations
+.. _USAGE: https://github.com/googleapis/artman/blob/master/USAGE.rst
 
 
 Python Versions
@@ -191,7 +66,7 @@ stable.
 Details
 -------
 
-For detailed documentation of the modules in gax-python, please watch `DOCUMENTATION`_.
+For detailed documentation of the modules in artman, please watch `DOCUMENTATION`_.
 
 .. _`DOCUMENTATION`: https://googleapis-artman.readthedocs.org/
 
@@ -201,4 +76,4 @@ License
 
 BSD - See `LICENSE`_ for more information.
 
-.. _`LICENSE`: https://github.com/googleapis/gax-python/blob/master/LICENSE
+.. _`LICENSE`: https://github.com/googleapis/artman/blob/master/LICENSE

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -1,0 +1,150 @@
+Usage
+=====
+
+Don't use this yet
+------------------
+
+**N.B. For now, unless you are part of the googleapis development team, don't try to use this.**
+
+These commands depend on tools that are not yet published, and will currently
+ only work in the development environments of the development team.
+
+In particular
+- the installation prequisites described need to installed locally
+- an as yet unpublished branch of googleapis containing the pipeline configuration should be available
+- the pipelines rely on as yet unpublished code-generation tool
+
+Prerequisites
+-------------
+
+The pipeline is used to create artifacts in a number of different programming
+languages, and needs various tools to do this.
+
+For day-to-day use, these tools should be installed locally.  There is a
+Dockerfile_ that sets up the environment with all prerequisites installed, please
+use that as a reference for setting up a local environment.
+
+.. _`Dockerfile`: https://github.com/googleapis/artman/blob/master/Dockerfile
+
+Try it out
+----------
+
+Local
+*****
+
+To execute a build pipeline locally, try the following example command:
+
+  ::
+
+     python execute_pipeline.py \
+       --pipeline_kwargs={\'sleep_secs\':2} SamplePipeline
+
+To execute a build pipeline remotely, start two consoles and run the following command
+in one console:
+
+  ::
+
+     python start_conductor.py
+
+
+And then run the following command for multiple times with different parameter:
+
+  ::
+
+     python execute_pipeline.py \
+       --pipeline_kwargs={\'sleep_secs\':2} \
+       --remote_mode SamplePipeline
+
+Please note, there is no guarantee that your pipeline job will be claimed by the
+conductor running on your machine. It can also be picked up by other conductor
+processes. You can run the second command for multiple times, and chances are
+good that your conductor will pick up one job at least.
+
+Python (logging)
+****************
+
+  ::
+
+     python execute_pipeline.py \
+        --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_python,\
+        ../googleapis/pipeline_config/pipeline_common.yaml:default|python" \
+        PythonGrpcClientPipeline
+
+     python execute_pipeline.py \
+        --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_python,\
+        ../googleapis/pipeline_config/pipeline_common.yaml:default|python" \
+        PythonVkitClientPipeline
+
+
+Java (pubsub)
+*************
+
+  ::
+
+     python execute_pipeline.py \
+        --config "../googleapis/pipeline_config/pipeline_core.yaml:core,\
+        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
+        JavaCorePipeline
+
+     python execute_pipeline.py \
+        --config "../googleapis/pipeline_config/pipeline_pubsub.yaml:pubsub_common|pubsub_java,\
+        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
+        JavaGrpcClientPipeline
+
+     python execute_pipeline.py \
+        --config "../googleapis/pipeline_config/pipeline_pubsub.yaml:pubsub_common|pubsub_java,\
+        ../googleapis/pipeline_config/pipeline_common.yaml:default|java" \
+        JavaVkitClientPipeline
+
+
+Go (logging)
+************
+
+To run the Go pipeline, first the core protos have to be compiled into the
+output directory.  Note: this won't be necessary once there is a public
+repository for the core proto pb.go files.
+
+  ::
+
+     python execute_pipeline.py \
+       --config "../googleapis/pipeline_config/pipeline_core.yaml:core,\
+       ../googleapis/pipeline_config/pipeline_logging.yaml:logging_go,\
+       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
+       GoCoreProtoPipeline
+
+
+The actual Go pipeline is as follows:
+
+  ::
+
+     python execute_pipeline.py \
+       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go|logging_type,\
+       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
+       GoCoreProtoPipeline
+
+     python execute_pipeline.py \
+       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go,\
+       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
+       GoGrpcClientPipeline
+
+     python execute_pipeline.py \
+       --config "../googleapis/pipeline_config/pipeline_logging.yaml:logging_common|logging_go,\
+       ../googleapis/pipeline_config/pipeline_common.yaml:default|go" \
+       GoVkitClientPipeline
+
+
+Pipeline configuration
+----------------------
+
+artman build pipelines are configured using yaml files with configuration data to
+run pipeline tasks.
+
+googleapis/pipeline_config/pipeline_common.yaml
+
+- default: Default configuration for all pipelines
+- {language}: Language specific configuration
+
+googleapis/pipeline_config/pipeline_{API}.yaml
+
+- {API}_common: cross language API specific configuration
+- {API}_{language}: API x language configurations


### PR DESCRIPTION
- Move usage instructions to USAGE.rst
- Fix some incorrect references
- In USAGE.rst, add a warning that the library is in development and can
  only be used by the development team at the moment