### PR TITLE
Introduce a new pipeline for remote execution

### DIFF
--- a/api_codegen.py
+++ b/api_codegen.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI to execute pipeline of code generation.
+
+This runs the pipeline tasks remotely by default and asks remote tasks
+to load the pipeline configs there, instead of specifying the config
+from the command line.
+
+TODO: Currently this command assumes all service proto files and
+Gapic YAML files are checked in to googleapis repository. We will
+want to allow supplying those files from the command line instead.
+"""
+
+
+import argparse
+
+from taskflow import engines
+from pipeline.pipelines import pipeline_factory
+from pipeline.utils import job_util
+
+
+def main():
+    parser = _CreateArgumentParser()
+    flags = parser.parse_args()
+    kwargs = {
+        'language': flags.language,
+        'api_version': flags.api,
+        'client_type': flags.client_type,
+        'reporoot': flags.reporoot,
+    }
+    pipeline = pipeline_factory.ConfigLoadingCodeGenerationPipeline(**kwargs)
+    if flags.run_locally:
+        engine = engines.load(pipeline.flow, engine='serial',
+                              store=pipeline.kwargs)
+        engine.run()
+    else:
+        job_util.post_remote_pipeline_job(pipeline)
+
+
+def _CreateArgumentParser():
+    parser = argparse.ArgumentParser(
+        description='''CLI to execute pipeline of code generation.
+
+        This runs the code generation pipeline with asking tasks to load the
+        pipeline configs on their side. This helps remote execution, because the
+        commandline users (you) don't have to bring the configuration files
+        locally.''')
+
+    parser.add_argument('--language', '-l', type=str,
+                        help='The target programming language to be generated')
+    parser.add_argument(
+        '--api', '-a', type=str,
+        help='The API name with version (e.g. logging/v2 or pubsub/v1)')
+    parser.add_argument('--client_type', default='gapic', type=str,
+                        choices=['gapic', 'grpc'],
+                        help='The type of the client to be generated')
+    parser.add_argument(
+        '--reporoot', type=str, default='..',
+        help='Change the path to find googleapis repository when specified')
+    parser.add_argument(
+        '--run_locally', action='store_true',
+        help='For debug. When specified, run the pipeline on the local machine')
+    return parser
+
+
+if __name__ == "__main__":
+  main()

--- a/execute_pipeline.py
+++ b/execute_pipeline.py
@@ -37,11 +37,10 @@ Example:
 
 import argparse
 import ast
-import os
-import yaml
 
-from taskflow import engines, task
+from taskflow import engines
 from pipeline.pipelines import pipeline_factory
+from pipeline.utils import config_util
 from pipeline.utils import job_util
 
 
@@ -88,16 +87,7 @@ def _CreateArgumentParser():
 def _load_config_spec(config_spec, repl_vars):
   (config_path, config_sections) = config_spec.strip().split(':')
   config_sections = config_sections.split('|')
-  data = {}
-  with open(config_path) as config_file:
-    all_config_data = yaml.load(config_file)
-  for section in config_sections:
-    data.update(all_config_data[section])
-
-  repl_vars["THISDIR"] = os.path.dirname(config_path)
-  _var_replace_config_data(data, repl_vars)
-  del repl_vars["THISDIR"]
-  return data
+  return config_util.load_config(config_path, config_sections, repl_vars)
 
 
 def _parse_args():
@@ -120,21 +110,6 @@ def _parse_args():
   return (flags.pipeline_name,
           pipeline_args,
           flags.remote_mode)
-
-
-def _var_replace_config_data(data, repl_vars):
-  for (k, v) in data.items():
-    if type(v) is list:
-      data[k] = [_var_replace(lv, repl_vars) for lv in v]
-    elif type(v) is not bool:
-      data[k] = _var_replace(v, repl_vars)
-
-
-def _var_replace(in_str, repl_vars):
-  new_str = in_str
-  for (k, v) in repl_vars.iteritems():
-    new_str = new_str.replace('${' + k + '}', v)
-  return new_str
 
 
 if __name__ == "__main__":

--- a/pipeline/pipelines/pipeline_base.py
+++ b/pipeline/pipelines/pipeline_base.py
@@ -29,7 +29,8 @@ class PipelineBase(object):
 
     def build_flow(self, **kwargs):
         """Make the task flow based on kwargs."""
-        self.validate_kwargs(**kwargs)
+        if 'suppress_validate_kwargs' not in kwargs:
+            self.validate_kwargs(**kwargs)
 
         # Call do_make_flow implemented by subclass to make the flow.
         flow = self.do_build_flow(**kwargs)

--- a/pipeline/tasks/config_tasks.py
+++ b/pipeline/tasks/config_tasks.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tasks related to read config data from local files."""
+
+import os
+
+from pipeline.utils import config_util
+from pipeline.tasks import task_base
+
+
+class ConfigReadTask(task_base.TaskBase):
+    """A task to read pipeline configs from local files.
+
+    As the result, the pipeline arguments will be loaded from the local
+    environment of the task execution instead of passing from the commandline.
+    This separation is helpful when the pipeline tasks run in remote clusters.
+    """
+
+    default_provides = set(['src_proto_path', 'import_proto_path',
+                            'toolkit_path', 'output_dir', 'service_yaml',
+                            'gapic_language_yaml', 'gapic_api_yaml',
+                            'auto_merge', 'auto_resolve', 'ignore_base',
+                            'final_repo_dir', 'api_name'])
+
+    def execute(self, reporoot, language, api_version):
+        config_base = os.path.join(reporoot, 'googleapis', 'gapic')
+        language_config = os.path.join(config_base, 'lang', 'common.yaml')
+        gapic_config = os.path.join(config_base, 'api', 'artman_common.yaml')
+        api_name = api_version.split('/')[0]
+        repl_vars = {
+            'REPOROOT': reporoot,
+            'API_VERSION': api_version,
+            'API_NAME': api_name,
+        }
+        data = {'api_name': api_name}
+        data.update(config_util.load_config(
+            gapic_config, ['common', language], repl_vars))
+        data.update(config_util.load_config(
+            language_config, ['default', language], repl_vars))
+        return data

--- a/pipeline/utils/config_util.py
+++ b/pipeline/utils/config_util.py
@@ -1,0 +1,46 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities of loading YAML config from files with variable replacements."""
+
+import os
+import yaml
+
+
+def load_config(config_path, config_sections, repl_vars):
+    data = {}
+    with open(config_path) as config_file:
+        all_config_data = yaml.load(config_file)
+    for section in config_sections:
+        data.update(all_config_data[section])
+
+    repl_vars["THISDIR"] = os.path.dirname(config_path)
+    _var_replace_config_data(data, repl_vars)
+    del repl_vars["THISDIR"]
+    return data
+
+
+def _var_replace_config_data(data, repl_vars):
+    for (k, v) in data.items():
+        if type(v) is list:
+            data[k] = [_var_replace(lv, repl_vars) for lv in v]
+        elif type(v) is not bool:
+            data[k] = _var_replace(v, repl_vars)
+
+
+def _var_replace(in_str, repl_vars):
+    new_str = in_str
+    for (k, v) in repl_vars.iteritems():
+        new_str = new_str.replace('${' + k + '}', v)
+    return new_str

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
     license='Apache-2.0',
     install_requires=requirements,
     packages=setuptools.find_packages(),
-    scripts=['execute_pipeline.py', 'start_conductor.py'],
+    scripts=['execute_pipeline.py', 'start_conductor.py', 'api_codegen.py'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
The new pipeline loads the pipeline config files as a step of
tasks and passes the loaded arguments to the actual pipeline.

This helps for remote execution, so the users don't have to
set up the configs or protos repository locally.