### PR TITLE
Added command to update brew in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ WORKDIR /home/linuxbrew
 ENV PATH /home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 ENV SHELL /bin/bash
 RUN yes |ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
+RUN brew update
 RUN brew doctor || true
 
 # Install protoc and grpc.


### PR DESCRIPTION
When building the dockerfile it would error by displaying the following error:
"Error: Unsupported special dependency :perl".

The linuxbrew that is installed to the image needs some updating in order to install some things later in the Dockerfile. I added a brew update command to the install linuxbrew step to alleviate this problem.

Pre-push hook installed.

Change-Id: Ia2387db9b62a82ed14462335c830d2bc17b2a60f