### PR TITLE
Stop building whl file for grpc-python

### DIFF
--- a/pipeline/pipelines/code_generation_pipeline.py
+++ b/pipeline/pipelines/code_generation_pipeline.py
@@ -84,9 +84,7 @@ class PythonGrpcClientPipeline(pipeline_base.PipelineBase):
     def do_build_flow(self, **kwargs):
         flow = linear_flow.Flow('grpc-codegen')
         flow.add(protoc_tasks.GrpcPackmanTask('Packman', inject=kwargs),
-                 package_tasks.GrpcPackageDirTask('PackageDir', inject=kwargs),
-                 package_tasks.PythonPackageGenTask('GrpcPackageGen',
-                                                    inject=kwargs))
+                 package_tasks.GrpcPackageDirTask('PackageDir', inject=kwargs))
         return flow
 
     def validate_kwargs(self, **kwargs):

--- a/test/testdata/python_grpc_client_pipeline.baseline
+++ b/test/testdata/python_grpc_client_pipeline.baseline
@@ -1,2 +1,1 @@
 gen-api-package --api_name=library/v1 -l python -o {OUTPUT}
-python ./setup.py bdist_wheel


### PR DESCRIPTION
If output directory is not clean (contains existing files),
packman generates a wrong setup.py and generating whl fails.

The misbehavior of packman is actually due to the side products
of this task, so simply removing task would solve the problem.

Ideally packman should be fixed to ignore unrelated files for
setup.py.