### PR TITLE
Simplify pipeline execution with presets

### DIFF
--- a/USAGE.rst
+++ b/USAGE.rst
@@ -111,7 +111,7 @@ Java (pubsub)
      python execute_pipeline.py \
         --config "../googleapis/gapic/core/artman_core.yaml,\
         ../googleapis/gapic/lang/common.yaml" \
-        --language java
+        --language java \
         GrpcClientPipeline
 
      python execute_pipeline.py \


### PR DESCRIPTION
For the default tasks you can use a short command:
**python execute_pipeline.py --preset api-language-task** 
Note: now the task can be one of gapic | grpc | core

e.g.
python execute_pipeline.py --preset pubsub-java-gapic

Note: Either pipeline name or preset needs to be provided in the argument to execute the pipeline.

Please let me know what you think. Thanks!