### PR TITLE
Support artman remote execution. Instead of running artman locally, w…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git
 
 # Install runtime packages.
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     ruby \
     python \
     python-dev \
     python-pip \
-    openjdk-7-jre-headless
+    unzip \
+    perl \
+    openjdk-7-jdk
+
+# Define commonly used JAVA_HOME variable
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ADD ./scripts /scripts
 WORKDIR /scripts
 # This is need to install nodejs 4.x otherwise nodejs 0.x will be installed.
 RUN bash setup_node4.sh
-RUN apt-get install -y nodejs 
+RUN apt-get install -y nodejs
 
 # Install linuxbrew.
 RUN useradd -m -s /bin/bash linuxbrew
@@ -40,11 +46,12 @@ USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH /home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 ENV SHELL /bin/bash
-RUN yes |ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/linuxbrew/go/install)"
+RUN yes |ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)"
 RUN brew doctor || true
 
 # Install protoc and grpc.
-RUN curl -s https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install | bash -s
+RUN brew tap grpc/grpc
+RUN brew install --with-plugins grpc
 
 # Install Go1.6 from linuxbrew.
 RUN brew install go
@@ -56,7 +63,7 @@ ENV PATH $GOPATH/bin:/home/linuxbrew/.linuxbrew/opt/go/libexec/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 # Install pacman
-RUN npm install -g googleapis-packman
+RUN npm install -g googleapis-packman@0.7.3
 
 # Setup tools for codegen of Ruby
 RUN gem install rubocop --version '= 0.39.0' --no-ri --no-rdoc
@@ -67,9 +74,10 @@ RUN gem install rake --version '= 10.5.0' --no-ri --no-rdoc
 WORKDIR /
 RUN git clone https://github.com/googleapis/googleapis
 RUN git clone https://github.com/googleapis/toolkit
+ENV TOOLKIT_HOME /toolkit
 
 # Run the pipeline.
-# TODO(cbao): pipeline should be installed from package manager.
+# TODO(ethanbao): pipeline should be installed from package manager.
 ADD . /src
 WORKDIR /src
 RUN pip install -r requirements.txt

--- a/execute_pipeline.py
+++ b/execute_pipeline.py
@@ -37,51 +37,87 @@ Example:
 
 import argparse
 import ast
+import base64
 import os
+import tempfile
+import time
+import uuid
 import yaml
 
-from taskflow import engines, task
+from gcloud import storage
+from gcloud import logging
+from taskflow import engines, task, states
 from pipeline.pipelines import pipeline_factory
-from pipeline.utils import job_util
+from pipeline.utils import job_util, pipeline_util
 
 
 def main():
-  pipeline_name, pipeline_kwargs, remote_mode = _parse_args()
-  pipeline = pipeline_factory.make_pipeline(pipeline_name, **pipeline_kwargs)
+  pipeline_name, pipeline_kwargs, env, local_repo = _parse_args()
 
-  if remote_mode:
-    job_util.post_remote_pipeline_job(pipeline)
+  if local_repo:
+    pipeline_kwargs = _load_local_repo(local_repo, **pipeline_kwargs)
+
+  if env:
+    # Execute pipeline task remotely based on the specified env param.
+    pipeline = pipeline_factory.make_pipeline(
+        pipeline_name, True, **pipeline_kwargs)
+    jb = job_util.post_remote_pipeline_job_and_wait(pipeline, env)
+    task_details, flow_detail = job_util.fetch_job_status(jb, env)
+
+    for task_detail in task_details:
+        if task_detail.name == 'BlobUploadTask' and task_detail.results:
+            bucket_name, path, _ = task_detail.results
+            pipeline_util.download_from_gcs(bucket_name, path,
+                                            os.path.join(tempfile.gettempdir(),
+                                            'artman-remote'))
+
+    if flow_detail.state != 'SUCCESS':
+      # Print the remote log if the pipeline execution completes but not with
+      # SUCCESS status.
+      _print_log(pipeline_kwargs['pipeline_id'])
+
   else:
-    # Hardcoded to execute the pipeline in serial engine, though not necessarily.
-    engine = engines.load(pipeline.flow, engine="serial", store=pipeline.kwargs)
+    pipeline = pipeline_factory.make_pipeline(
+        pipeline_name, False, **pipeline_kwargs)
+    # Hardcoded to run pipeline in serial engine, though not necessarily.
+    engine = engines.load(pipeline.flow, engine='serial', store=pipeline.kwargs)
     engine.run()
 
 
 def _CreateArgumentParser():
   parser = argparse.ArgumentParser()
-  parser.add_argument("pipeline_name",
-                      type=str,
-                      help="The name of the pipeline to run")
   parser.add_argument(
-      "--remote_mode",
-      action="store_true",
-      help="When specified, the pipeline will be executed remotely")
-  parser.add_argument(
-      "--pipeline_kwargs",
+      'pipeline_name',
       type=str,
-      default="{}",
+      help='The name of the pipeline to run')
+  parser.add_argument(
+      '--pipeline_kwargs',
+      type=str,
+      default='{}',
       help=
-      "pipeline_kwargs string, e.g. {\'sleep_secs\':3, \'type\':\'sample\'}")
+      'pipeline_kwargs string, e.g. {\'sleep_secs\':3, \'type\':\'sample\'}')
   parser.add_argument(
-      "--config",
+      '--config',
       type=str,
-      help="Comma-delimited list of the form "
-          + "/path/to/config.yaml:config_section")
+      help='Comma-delimited list of the form '
+          + '/path/to/config.yaml:config_section')
   parser.add_argument(
-      "--reporoot",
+      '--reporoot',
       type=str,
-      default="..",
-      help="Root directory where the input, output, and tool repositories live")
+      default='..',
+      help='Root directory where the input, output, and tool repositories live')
+  parser.add_argument(
+      '--local_repo',
+      type=str,
+      default=None,
+      help='Directory where local proto and gapic configs lives.')
+  parser.add_argument(
+        '--env',
+        type=str,
+        default=None,
+        help='Environment for remote execution (valid value is \'remote\', and '
+             'is case-insensitive. Pipeline will be executed locally if this '
+             'flag is not provided.')
   return parser
 
 
@@ -94,9 +130,9 @@ def _load_config_spec(config_spec, repl_vars):
   for section in config_sections:
     data.update(all_config_data[section])
 
-  repl_vars["THISDIR"] = os.path.dirname(config_path)
+  repl_vars['THISDIR'] = os.path.dirname(config_path)
   _var_replace_config_data(data, repl_vars)
-  del repl_vars["THISDIR"]
+  del repl_vars['THISDIR']
   return data
 
 
@@ -104,8 +140,22 @@ def _parse_args():
   parser = _CreateArgumentParser()
   flags = parser.parse_args()
 
+  repo_root = flags.reporoot
   pipeline_args = {}
-  repl_vars = {"REPOROOT": flags.reporoot}
+
+  if flags.env:
+    pipeline_id = str(uuid.uuid4())
+    # Use a unique randome temp directory for remote execution.
+    # TODO(ethanbao): Let remote artman decide the temp directory.
+    repo_root = '/tmp/artman/%s' % pipeline_id
+    pipeline_args['pipeline_id'] = pipeline_id
+
+  pipeline_args['repo_root'] = repo_root
+  # TODO(ethanbao): Remove TOOLKIT_HOME var after toolkit_path is removed from
+  # gapic yaml.
+  repl_vars = {'REPOROOT': repo_root,
+               'TOOLKIT_HOME': os.path.join(flags.reporoot, 'toolkit')}
+
   if flags.config:
     for config_spec in flags.config.split(','):
       config_args = _load_config_spec(config_spec, repl_vars)
@@ -113,13 +163,14 @@ def _parse_args():
 
   cmd_args = ast.literal_eval(flags.pipeline_kwargs)
   pipeline_args.update(cmd_args)
-  print "Final args:"
+  print 'Final args:'
   for (k, v) in pipeline_args.iteritems():
-    print " ", k, ":", v
+    print ' ', k, ':', v
 
   return (flags.pipeline_name,
           pipeline_args,
-          flags.remote_mode)
+          flags.env.lower() if flags.env else None,
+          flags.local_repo)
 
 
 def _var_replace_config_data(data, repl_vars):
@@ -136,6 +187,51 @@ def _var_replace(in_str, repl_vars):
     new_str = new_str.replace('${' + k + '}', v)
   return new_str
 
+
+def _load_local_repo(private_repo_root, **pipeline_kwargs):
+  files_dict = {}
+  for root, dirs, files in os.walk(private_repo_root):
+      for fname in files:
+        path = os.path.join(root, fname)
+        rel_path = os.path.relpath(path, private_repo_root)
+        with open(path, 'r') as f:
+          files_dict[_normalize_path(rel_path)] = base64.b64encode(f.read())
+
+  pipeline_kwargs['files_dict'] = files_dict
+  return pipeline_kwargs
+
+def _normalize_path(path):
+    """Normalize the file path into one using slash as the seperator."""
+    parts = []
+    while True:
+        head, tail = os.path.split(path)
+        if head == path:
+            assert not tail
+            if path:
+                parts.append(head)
+            break
+        parts.append(tail)
+        path = head
+    parts.reverse()
+    return "/".join(parts)
+
+def _print_log(pipeline_id):
+  # Fetch the cloud logging entry if the exection fails. Wait for 30 secs,
+  # because it takes a while for the logging to become available.
+  print('The remote pipeline execution failed. It will wait for 30 secs before '
+        'fetching the log for remote pipeline execution.')
+  time.sleep(30)
+  try:
+      client = logging.Client()
+      logger = client.logger(pipeline_id)
+      entries, token = logger.list_entries()
+      for entry in entries:
+          print entry.payload
+  except:
+      pass
+
+  print('You can always run the following command to fetch the log entry:\n'
+        '    gcloud beta logging read "logName=projects/vkit-pipeline/logs/%s"' % pipeline_id)
 
 if __name__ == "__main__":
   main()

--- a/pipeline/pipelines/pipeline_base.py
+++ b/pipeline/pipelines/pipeline_base.py
@@ -52,6 +52,13 @@ class PipelineBase(object):
         """
         raise NotImplementedError('Subclass must implement abstract method')
 
+    def require_additional_tasks_for_remote_execution(self):
+        """Return true, if additional tasks are needed for remote execution.
+
+        TODO(ethanbao): Return a list of tasks that need to be added.
+        """
+        return True
+
     @property
     def flow(self):
         return self._flow

--- a/pipeline/pipelines/pipeline_factory.py
+++ b/pipeline/pipelines/pipeline_factory.py
@@ -11,17 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Factory function that recreates pipeline based on pipeline name and
 kwargs."""
+
+import os
+import time
+import uuid
 
 from pipeline.pipelines import pipeline_base
 # These are required to list the subclasses of pipeline_base
 from pipeline.pipelines import sample_pipeline  # noqa
 from pipeline.pipelines import code_generation_pipeline  # noqa
 
+from pipeline.tasks import io_tasks
 
-def make_pipeline_flow(pipeline_name, **kwargs):
+
+def make_pipeline_flow(pipeline_name, remote_mode=False, **kwargs):
     """Factory function to make a GAPIC pipeline.
 
     Because the GAPIC pipeline is using OpenStack Taskflow, this factory
@@ -35,13 +40,17 @@ def make_pipeline_flow(pipeline_name, **kwargs):
     the reimportable name can be located).
 
     """
-    return make_pipeline(pipeline_name, **kwargs).flow
+    return make_pipeline(pipeline_name, remote_mode, **kwargs).flow
 
 
-def make_pipeline(pipeline_name, **kwargs):
+def make_pipeline(pipeline_name, remote_mode=False, **kwargs):
     for cls in _rec_subclasses(pipeline_base.PipelineBase):
         if cls.__name__ == pipeline_name:
             print("Create %s instance." % pipeline_name)
+            if 'TOOLKIT_HOME' in os.environ:
+                kwargs['toolkit_path'] = os.environ['TOOLKIT_HOME']
+            if remote_mode:
+                return create_pipeline_for_remote_execution(cls, **kwargs)
             return cls(**kwargs)
     raise ValueError("Invalid pipeline name: %s" % pipeline_name)
 
@@ -55,3 +64,24 @@ def _rec_subclasses(cls):
             subclasses.append(subcls)
             subclasses += _rec_subclasses(subcls)
     return subclasses
+
+
+def create_pipeline_for_remote_execution(cls, additional_tasks=True, **kwargs):
+    tmp_id = str(uuid.uuid4())
+    filename = tmp_id + '.tar.gz'
+    kwargs['tarfile'] = filename
+    kwargs['bucket_name'] = 'pipeline'
+    kwargs['src_path'] = filename
+    kwargs['dest_path'] = time.strftime('%Y/%m/%d') + '/' + filename
+
+    pipeline = cls(**kwargs)
+    # Add additional tasks for remote execution.
+    if pipeline.require_additional_tasks_for_remote_execution():
+        pipeline.flow.add(
+            io_tasks.PrepareUploadDirTask('PrepareUploadDirTask',
+                                          inject=kwargs),
+            io_tasks.BlobUploadTask('BlobUploadTask',
+                                    inject=kwargs),
+            io_tasks.CleanupTempDirsTask('CleanupTempDirsTask',
+                                         inject=kwargs))
+    return pipeline

--- a/pipeline/pipelines/sample_pipeline.py
+++ b/pipeline/pipelines/sample_pipeline.py
@@ -34,3 +34,6 @@ class SamplePipeline(pipeline_base.PipelineBase):
     def validate_kwargs(self, **kwargs):
         if 'sleep_secs' not in kwargs:
             raise ValueError('sleep_secs must be provided')
+
+    def require_additional_tasks_for_remote_execution(self):
+        return False

--- a/pipeline/tasks/format_tasks.py
+++ b/pipeline/tasks/format_tasks.py
@@ -37,7 +37,7 @@ class JavaFormatTask(task_base.TaskBase):
                 if filename.endswith('.java'):
                     targetFile = os.path.abspath(os.path.join(root, filename))
                     targetFiles.append(targetFile)
-        subprocess.check_call(
+        self.exec_command(
             ['java', '-jar', path, '--replace'] + targetFiles)
 
     def validate(self):
@@ -67,7 +67,7 @@ class PythonFormatTask(task_base.TaskBase):
 class GoFormatTask(task_base.TaskBase):
     def execute(self, intermediate_code_dir):
         print 'Formatting files in ' + os.path.abspath(intermediate_code_dir)
-        subprocess.check_call(['gofmt', '-w', intermediate_code_dir])
+        self.exec_command(['gofmt', '-w', intermediate_code_dir])
 
     def validate(self):
         return [go_requirements.GoFormatRequirements]

--- a/pipeline/tasks/gapic_tasks.py
+++ b/pipeline/tasks/gapic_tasks.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tasks related to generation of GAPIC wrappers"""
 
 import os
-import subprocess
 import yaml
 
 from pipeline.tasks import packman_tasks
@@ -29,16 +27,16 @@ class GapicConfigGenTask(task_base.TaskBase):
 
     def execute(self, toolkit_path, descriptor_set, output_dir, api_name):
         config_gen_dir = os.path.join(output_dir, api_name + '-config-gen')
-        subprocess.check_call(['mkdir', '-p', config_gen_dir])
+        self.exec_command(['mkdir', '-p', config_gen_dir])
         config_gen_path = os.path.join(config_gen_dir,
                                        api_name + '_gapic.yaml')
         args = [
             '--descriptor_set=' + os.path.abspath(descriptor_set),
             '--output=' + os.path.abspath(config_gen_path)
-            ]
+        ]
         clargs = '-Pclargs=' + ','.join(args)
-        subprocess.check_call([os.path.join(toolkit_path, 'gradlew'),
-                               '-p', toolkit_path, 'runConfigGen', clargs])
+        self.exec_command([os.path.join(toolkit_path, 'gradlew'), '-p',
+                           toolkit_path, 'runConfigGen', clargs])
 
         return config_gen_path
 
@@ -52,8 +50,8 @@ class GapicConfigMoveTask(task_base.TaskBase):
     def _move_to(self, intermediate_config_location, gapic_api_yaml):
         error_fmt = 'Could not move generated config file \
                     from "{0}" to "{1}": '.format(
-                        os.path.abspath(intermediate_config_location),
-                        [os.path.abspath(c_out) for c_out in gapic_api_yaml])
+            os.path.abspath(intermediate_config_location),
+            [os.path.abspath(c_out) for c_out in gapic_api_yaml])
 
         if len(gapic_api_yaml) > 1:
             raise ValueError(error_fmt + 'Multiple locations specified')
@@ -67,9 +65,8 @@ class GapicConfigMoveTask(task_base.TaskBase):
     def execute(self, intermediate_config_location, gapic_api_yaml):
         conf_out = self._move_to(intermediate_config_location, gapic_api_yaml)
         if conf_out:
-            subprocess.check_call(['mkdir', '-p', os.path.dirname(conf_out)])
-            subprocess.check_call(['mv', intermediate_config_location,
-                                   conf_out])
+            self.exec_command(['mkdir', '-p', os.path.dirname(conf_out)])
+            self.exec_command(['mv', intermediate_config_location, conf_out])
         return
 
     def validate(self):
@@ -84,19 +81,19 @@ class GapicCodeGenTask(task_base.TaskBase):
                 gapic_api_yaml, gapic_language_yaml, output_dir, api_name):
         code_root = os.path.join(output_dir,
                                  api_name + '-gapic-gen-' + language)
-        subprocess.check_call(['rm', '-rf', code_root])
+        self.exec_command(['rm', '-rf', code_root])
         gapic_yaml = gapic_api_yaml + gapic_language_yaml
         gapic_args = ['--gapic_yaml=' + os.path.abspath(yaml)
                       for yaml in gapic_yaml]
         service_args = ['--service_yaml=' + os.path.abspath(yaml)
                         for yaml in service_yaml]
         args = [
-            '--descriptor_set=' + os.path.abspath(descriptor_set),
-            '--output=' + os.path.abspath(code_root)
-            ] + service_args + gapic_args
+            '--descriptor_set=' + os.path.abspath(descriptor_set), '--output='
+            + os.path.abspath(code_root)
+        ] + service_args + gapic_args
         clargs = '-Pclargs=' + ','.join(args)
-        subprocess.check_call([os.path.join(toolkit_path, 'gradlew'),
-                               '-p', toolkit_path, 'runVGen', clargs])
+        self.exec_command([os.path.join(toolkit_path, 'gradlew'), '-p',
+                           toolkit_path, 'runVGen', clargs])
 
         return code_root
 
@@ -110,22 +107,21 @@ class GapicCopyTask(task_base.TaskBase):
 
     def execute(self, final_repo_dir, intermediate_code_dir):
         # Simply removes the previous code generation results.
-        subprocess.check_call(['rm', '-rf', final_repo_dir])
-        subprocess.check_call([
-            'cp', '-rf', intermediate_code_dir, final_repo_dir])
+        self.exec_command(['rm', '-rf', final_repo_dir])
+        self.exec_command(['cp', '-rf', intermediate_code_dir, final_repo_dir])
 
 
 class GapicMergeTask(task_base.TaskBase):
     def execute(self, language, toolkit_path, final_repo_dir,
                 intermediate_code_dir, auto_merge, auto_resolve, ignore_base):
         final_code_root = os.path.abspath(final_repo_dir)
-        baseline_root = os.path.abspath(
-            os.path.join(final_repo_dir, 'baseline'))
+        baseline_root = os.path.abspath(os.path.join(final_repo_dir,
+                                                     'baseline'))
         args = [
             '--source_path=' + final_code_root,
             '--generated_path=' + os.path.abspath(intermediate_code_dir),
             '--baseline_path=' + baseline_root,
-            ]
+        ]
         if auto_merge:
             args.append('--auto_merge')
         if auto_resolve:
@@ -134,9 +130,8 @@ class GapicMergeTask(task_base.TaskBase):
             args.append('--ignore_base')
         clargs = '-Pclargs=' + ','.join(args)
         print 'Running synchronizer with args: ' + str(args)
-        subprocess.check_call([os.path.join(toolkit_path, 'gradlew'),
-                               '-p', toolkit_path, 'runSynchronizer',
-                               clargs])
+        self.exec_command([os.path.join(toolkit_path, 'gradlew'), '-p',
+                           toolkit_path, 'runSynchronizer', clargs])
         for root, subdirs, files in os.walk(final_code_root):
             for file in files:
                 if file.endswith('.orig'):
@@ -169,5 +164,6 @@ class GoExtractImportBaseTask(task_base.TaskBase):
 
 class GapicPackmanTask(packman_tasks.PackmanTaskBase):
     def execute(self, language, api_name, final_repo_dir):
+        # TODO: Use TaskBase.exec_command()
         self.run_packman(language, api_name, '--gax_dir=' + final_repo_dir,
                          '--template_root=templates/gax')

--- a/pipeline/tasks/io_tasks.py
+++ b/pipeline/tasks/io_tasks.py
@@ -1,0 +1,129 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tasks related to I/O."""
+
+import base64
+import os
+import shutil
+import urllib
+import zipfile
+
+from gcloud import storage
+from oauth2client.client import GoogleCredentials
+from pipeline.tasks import task_base
+
+
+def get_credential():
+    return GoogleCredentials.get_application_default()
+
+
+class BlobUploadTask(task_base.TaskBase):
+    """A task which uploads file to Google Cloud Storage.
+
+    It requires authentication be properly configured."""
+
+    default_provides = ('bucket', 'path', 'public_url')
+
+    def execute(self,
+                bucket_name,
+                src_path,
+                dest_path):
+        print "Start blob upload"
+        client = storage.Client(credentials=get_credential())
+        bucket = client.get_bucket(bucket_name)
+        blob = bucket.blob(dest_path)
+        with open(src_path, 'r') as f:
+            blob.upload_from_file(f)
+        print "Uploaded to %s" % blob.public_url
+
+        return bucket_name, dest_path, blob.public_url
+
+
+class BlobDownloadTask(task_base.TaskBase):
+    """A task which downloads file to Google Cloud Storage.
+
+    It requires authentication be properly configured."""
+
+    def execute(self, bucket_name, path, output_dir):
+        client = storage.Client(credentials=get_credential())
+        bucket = client.get_bucket(bucket_name)
+        blob = bucket.get_blob(path)
+        if not blob:
+            print 'Cannot find the output from GCS.'
+            return
+        filename = os.path.join(output_dir, path)
+        if not os.path.exists(os.path.dirname(filename)):
+            try:
+                os.makedirs(os.path.dirname(filename))
+            except:
+                raise
+        with open(filename, "w") as f:
+            blob.download_to_file(f)
+            print 'File downloaded to %s' % f.name
+
+
+class PrepareUploadDirTask(task_base.TaskBase):
+    """Compress pipeline dir_to_upload into a file which can be uploaded to GCS.
+
+    Normally be used as the final step for pipeline job to return generated
+    content to its poster."""
+
+    def execute(self, repo_root, tarfile):
+        self.exec_command(['tar', '-C', repo_root, '-zcvf', tarfile, '.'])
+
+
+class CleanupTempDirsTask(task_base.TaskBase):
+    """Clean up all temporary directories"""
+
+    def execute(self, repo_root):
+        if os.path.exists(repo_root) and os.path.isdir(repo_root):
+            shutil.rmtree(repo_root)
+
+
+class PrepareGoogleapisDirTask(task_base.TaskBase):
+
+    default_provides = ('repo_dir')
+
+    def execute(self, repo_root, files_dict={}):
+        if os.path.exists(repo_root):
+            # Do nothing if the repo_root exists. The repo_root exists if
+            # artman is running locally.
+            return
+        print('root repo: %s' % repo_root)
+        try:
+            os.makedirs(repo_root)
+        except OSError as e:
+            raise e
+        testfile = urllib.FancyURLopener()
+        tmp_repo_file = os.path.join(repo_root, "file.zip")
+        testfile.retrieve(
+            "https://github.com/googleapis/googleapis/archive/master.zip",
+            tmp_repo_file)
+        zip_ref = zipfile.ZipFile(tmp_repo_file, 'r')
+        zip_ref.extractall(repo_root)
+        zip_ref.close()
+        os.remove(tmp_repo_file)
+        shutil.move(os.path.join(repo_root, "googleapis-master"),
+                    os.path.join(repo_root, "googleapis"))
+        repo_dir = os.path.join(repo_root, "googleapis")
+        # Write/overwrite the additonal files into the repo_dir so that user
+        # can include additional files which are not in the public repo.
+        for f, content in files_dict.iteritems():
+            filename = os.path.join(repo_dir, f)
+            if not os.path.exists(os.path.dirname(filename)):
+                os.makedirs(os.path.dirname(filename))
+            with open(filename, "w+") as text_file:
+                text_file.write(base64.b64decode(content))
+        return repo_dir

--- a/pipeline/tasks/package_tasks.py
+++ b/pipeline/tasks/package_tasks.py
@@ -24,7 +24,7 @@ from pipeline.tasks.requirements import ruby_requirements
 def _scoped_run_command(target_dir, commands):
     current_dir = os.getcwd()
     os.chdir(target_dir)
-    subprocess.check_call(commands)
+    subprocess.check_output(commands, stderr=subprocess.STDOUT)
     os.chdir(current_dir)
 
 

--- a/pipeline/tasks/packman_tasks.py
+++ b/pipeline/tasks/packman_tasks.py
@@ -14,7 +14,6 @@
 
 """Tasks related to generation of packman tool"""
 
-import subprocess
 
 from pipeline.tasks import task_base
 from pipeline.tasks.requirements import packman_requirements
@@ -26,7 +25,7 @@ class PackmanTaskBase(task_base.TaskBase):
         api_name = api_name.replace('-', '/')
         args = ['gen-api-package', '--api_name=' + api_name, '-l', language]
         args.extend(additional_args)
-        subprocess.check_call(args)
+        self.exec_command(args)
 
     def validate(self):
         return [packman_requirements.PackmanRequirements]

--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -107,7 +107,7 @@ class _PhpProtoParams:
     def grpc_plugin_path(self, dummy_toolkit_path):
         if self.path is None:
             self.path = subprocess.check_output(
-                ['which', 'protoc-gen-php'])[:-1]
+                ['which', 'protoc-gen-php'], stderr=subprocess.STDOUT)[:-1]
         return self.path
 
     def grpc_out_param(self, output_dir):
@@ -190,7 +190,9 @@ def _protoc_grpc_params(proto_params, pkg_dir, toolkit_path):
 def _prepare_pkg_dir(output_dir, api_name, language):
     proto_params = _PROTO_PARAMS_MAP[language]
     pkg_dir = os.path.join(output_dir, api_name + '-gen-' + language)
-    subprocess.check_call(['mkdir', '-p', proto_params.code_root(pkg_dir)])
+    subprocess.check_output([
+        'mkdir', '-p', proto_params.code_root(pkg_dir)],
+        stderr=subprocess.STDOUT)
     return pkg_dir
 
 
@@ -203,11 +205,11 @@ class ProtoDescGenTask(task_base.TaskBase):
         print 'Compiling descriptors {0}'.format(
             _find_protos(src_proto_path))
         desc_out_file = api_name + '.desc'
-        subprocess.check_call(['mkdir', '-p', output_dir])
+        self.exec_command(['mkdir', '-p', output_dir])
         # DescGen don't use _group_by_dirname right now because
         #   - it doesn't have to
         #   - and multiple invocation will overwrite the desc_out_file
-        subprocess.check_call(
+        self.exec_command(
             _protoc_header_params(
                 import_proto_path, src_proto_path, toolkit_path) +
             _protoc_desc_params(output_dir, desc_out_file) +
@@ -230,7 +232,7 @@ class ProtoCodeGenTask(task_base.TaskBase):
         for (dirname, protos) in _group_by_dirname(
                 _find_protos(src_proto_path)).items():
             print 'Generating protos {0}'.format(dirname)
-            subprocess.check_call(
+            self.exec_command(
                 _protoc_header_params(
                     import_proto_path, src_proto_path, toolkit_path) +
                 _protoc_proto_params(proto_params, pkg_dir, with_grpc=False) +
@@ -251,7 +253,7 @@ class GrpcCodeGenTask(task_base.TaskBase):
         for (dirname, protos) in _group_by_dirname(
                 _find_protos(src_proto_path)).items():
             print 'Running protoc with grpc plugin on {0}'.format(dirname)
-            subprocess.check_call(
+            self.exec_command(
                 _protoc_header_params(
                     import_proto_path, src_proto_path, toolkit_path) +
                 _protoc_grpc_params(proto_params, pkg_dir, toolkit_path) +
@@ -272,7 +274,7 @@ class ProtoAndGrpcCodeGenTask(task_base.TaskBase):
         for (dirname, protos) in _group_by_dirname(
                 _find_protos(src_proto_path)).items():
             print 'Running protoc and grpc plugin on {0}'.format(dirname)
-            subprocess.check_call(
+            self.exec_command(
                 _protoc_header_params(
                     import_proto_path, src_proto_path, toolkit_path) +
                 _protoc_proto_params(proto_params, pkg_dir, with_grpc=True) +
@@ -325,6 +327,9 @@ class GoLangUpdateImportsTask(task_base.TaskBase):
 
 
 class GrpcPackmanTask(packman_tasks.PackmanTaskBase):
-    def execute(self, language, api_name, output_dir, packman_flags=[]):
+    def execute(self, language, api_name, output_dir, packman_flags=[],
+                repo_dir=None):
         arg_list = [language, api_name, '-o', output_dir] + packman_flags
+        if repo_dir:
+            arg_list += ['-r', repo_dir]
         self.run_packman(*arg_list)

--- a/pipeline/tasks/publish_tasks.py
+++ b/pipeline/tasks/publish_tasks.py
@@ -14,7 +14,6 @@
 
 """Tasks for publishing artman output"""
 
-import subprocess
 from pipeline.tasks import task_base
 
 
@@ -24,14 +23,14 @@ class PypiUploadTask(task_base.TaskBase):
     def execute(self, repo_url, username, password, publish_env,
                 final_repo_dir):
         publish_url = repo_url + username + '/' + publish_env
-        subprocess.check_call(
+        self.exec_command(
             ['devpi',
              'login',
              '--password',
              password,
              username])
-        subprocess.check_call(['devpi', 'use', publish_url])
-        subprocess.check_call(
+        self.exec_command(['devpi', 'use', publish_url])
+        self.exec_command(
             ['devpi',
              'upload',
              '--no-vcs',
@@ -46,7 +45,7 @@ class MavenDeployTask(task_base.TaskBase):
     """Publishes to a Maven repository"""
     def execute(self, repo_url, username, password, publish_env,
                 final_repo_dir):
-        subprocess.check_call(
+        self.exec_command(
             [final_repo_dir + '/gradlew',
              'uploadArchives',
              '-PmavenRepoUrl=' + repo_url,

--- a/pipeline/utils/backend_helper.py
+++ b/pipeline/utils/backend_helper.py
@@ -22,13 +22,6 @@ from taskflow.persistence import backends as persistence_backends
 # Default host/port of ZooKeeper service.
 ZK_HOST = '104.197.10.180:2181'
 
-# Default jobboard configuration.
-JB_CONF = {
-    'hosts': ZK_HOST,
-    'board': 'zookeeper',
-    'path': '/dev/jobs',
-}
-
 # Default persistence configuration.
 PERSISTENCE_CONF = {
     'connection': 'zookeeper',
@@ -41,7 +34,11 @@ def default_persistence_backend():
     return persistence_backends.fetch(PERSISTENCE_CONF)
 
 
-def default_jobboard_backend(name):
-    return job_backends.fetch(name,
-                              JB_CONF,
+def get_jobboard(name, jobboard_name):
+    config = {
+        'hosts': ZK_HOST,
+        'board': 'zookeeper',
+        'path': '/taskflow/jobboard/zookeeper/' + jobboard_name,
+    }
+    return job_backends.fetch(name, config,
                               persistence=default_persistence_backend())

--- a/pipeline/utils/task_utils.py
+++ b/pipeline/utils/task_utils.py
@@ -11,15 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Utility functions related to tasks"""
 
 import subprocess
 
 
 def runGradleTask(task_name, task_path):
-    output = subprocess.check_output(
-        ['./gradlew', task_name], cwd=task_path)
+    output = subprocess.check_output(['./gradlew', task_name], cwd=task_path)
     # It is a convention that gradle task uses 'output: ' as
     # prefix in their output
     prefix = 'output: '

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 oslo.utils>=3.4.0 # Apache-2.0
 pyyaml>=3.11
-taskflow>=1.25.0,<2.0.0
+taskflow==1.25.0
 kazoo>=2.2.1
 google-apitools
-gcloud==0.10.0
+gcloud==0.15.0
 yapf>=0.6.2 # Apache-2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     'kazoo>=2.2.1',
     'oslo.utils>=3.4.0',
     'pyyaml>=3.11',
-    'taskflow>=1.25.0',
+    'taskflow>=1.25.0,<2.0.0',
     'yapf>=0.6.2'
 ]
 

--- a/start_conductor.py
+++ b/start_conductor.py
@@ -18,12 +18,28 @@
 """Main class to start conductor.
 """
 
+import argparse
+
 from pipeline.conductors import gapic_conductor
 
 
 def main():
-  gapic_conductor.run()
+  jobboard_name = _parse_args()
+  gapic_conductor.run(jobboard_name)
 
+def _parse_args():
+  parser = _CreateArgumentParser()
+  flags = parser.parse_args()
+  return flags.jobboard_name.lower()
+
+def _CreateArgumentParser():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--jobboard_name",
+      type=str,
+      default="remote",
+      help="The name of the jobboard to monitor.")
+  return parser
 
 if __name__ == '__main__':
   main()

--- a/test/test_gapic_conductor.py
+++ b/test/test_gapic_conductor.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from multiprocessing import Process
+import unittest
+
+from pipeline.pipelines import pipeline_factory
+from pipeline.utils import job_util
+from pipeline.conductors import gapic_conductor
+
+
+class ConductorE2ETest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # global jobboard name for testing.
+        cls.test_jobboard_name = 'test_jb_%s' % str(uuid.uuid4())
+        cls.p = Process(
+            target=_start_conductor, args=(cls.test_jobboard_name,))
+        cls.p.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.p.terminate()
+
+    def test_remote_sample_pipeline(self):
+        pipeline_kwargs = {'sleep_secs': 1}
+        pipeline = pipeline_factory.make_pipeline(
+            'SamplePipeline', True, **pipeline_kwargs)
+        jb = job_util.post_remote_pipeline_job_and_wait(
+            pipeline, self.test_jobboard_name)
+        task_details, flow_detail = job_util.fetch_job_status(
+            jb, self.test_jobboard_name)
+        self.assertEqual('SUCCESS', flow_detail.state)
+
+
+def _start_conductor(test_jobboard_name):
+    gapic_conductor.run(test_jobboard_name)

--- a/test/test_pipeline_baseline.py
+++ b/test/test_pipeline_baseline.py
@@ -19,8 +19,8 @@ from pipeline.pipelines import pipeline_factory
 from taskflow import engines
 
 
-def get_expected_calls(baseline, binding):
-    """Returns the list of expected calls of subprocess.check_call() and
+def get_expected_calls(baseline, binding, stderr=False):
+    """Returns the list of expected calls of subprocess.check_output() and
     subprocess.call().
 
     The expected commandlines are listed in the baseline files located
@@ -35,8 +35,12 @@ def get_expected_calls(baseline, binding):
     with open(filename) as f:
         for line in f:
             tokens = line.strip().split()
-            commands.append(mock.call([
-                token.format(**binding) for token in tokens]))
+            if stderr:
+                commands.append(mock.call([
+                    token.format(**binding) for token in tokens], stderr=-2))
+            else:
+                commands.append(mock.call([
+                    token.format(**binding) for token in tokens]))
     return commands
 
 
@@ -50,9 +54,11 @@ def check_calls_match(expected_calls, actual_calls):
 @mock.patch('pipeline.utils.task_utils.runGradleTask')
 @mock.patch('subprocess.call')
 @mock.patch('subprocess.check_call')
+@mock.patch('subprocess.check_output')
 @mock.patch('os.chdir')
 def _test_baseline(task_name, test_name, language, output_dir, extra_kwargs,
-                   mock_chdir, mock_check_call, mock_call, mock_gradle_task):
+                   mock_chdir, mock_check_output, mock_check_call, mock_call,
+                   mock_gradle_task):
     # Pipeline kwargs
     kwargs_ = {
         'src_proto_path': ['test/fake-repos/fake-proto'],
@@ -73,12 +79,14 @@ def _test_baseline(task_name, test_name, language, output_dir, extra_kwargs,
         'auto_merge': True,
         'auto_resolve': True,
         'ignore_base': False,
-        'final_repo_dir': output_dir + '/final'}
+        'final_repo_dir': output_dir + '/final',
+        'repo_root': '.'}
     kwargs_.update(extra_kwargs)
 
     # Mock output value of gradle tasks
     mock_gradle_task.return_value = 'MOCK_GRADLE_TASK_OUTPUT'
     mock_call.return_value = 0
+    mock_check_output.return_value = ''
 
     # Run pipeline
     pipeline = pipeline_factory.make_pipeline(task_name, **kwargs_)
@@ -87,8 +95,8 @@ def _test_baseline(task_name, test_name, language, output_dir, extra_kwargs,
 
     # Compare with the expected subprocess calls.
     expected_checked_calls = get_expected_calls(
-        test_name, {'CWD': os.getcwd(), 'OUTPUT': output_dir})
-    check_calls_match(expected_checked_calls, mock_check_call.mock_calls)
+        test_name, {'CWD': os.getcwd(), 'OUTPUT': output_dir}, True)
+    check_calls_match(expected_checked_calls, mock_check_output.mock_calls)
 
     # Some tasks can use subprocess.call() instead of check_call(), they are
     # tracked separately.


### PR DESCRIPTION
…hich requires users to install all dependencies on the dev machine, artman remote execution only requires users to install artman from pypi. This feature is implemented by:

1) Allow user to pass local proto/yaml files to remote artman conductors. The files content (base64 encoded) will be passed via pipeline argument. The mechanism might change in the future, but will be transparent to users.
2) The remote artman conductors (running on docker containers) is going to prepare a temporary directory. It will first download the latest googleapis repo, and then add/update the files in the repo with the ones uploaded from local machine. The temporary directory will be deleted after the execution.
3) The generated output (including the local googleapis repo) will be uploaded to Google Cloud Storage.
4) execute_pipeline.py will post the artman job and wait till the job is done. If the caller has access to the GCS bucket that is used to store uploaded generated output, it will be downloaded to local machine.

Things need to be improved in the followup PRs:
1) Improve the error message when the remote exectution fails.
2) Make sure that nothing gets left on the remote docker containers when the remote execution fails.
3) Add unit and e2e tests for remote execution.