### PR TITLE
Stop pylint'ing the test directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands = flake8 --max-complexity=8 pipeline --exclude='test/output' test
 [testenv:pylint-errors]
 deps = pylint
        -r{toxinidir}/requirements.txt
-commands = pylint -f colorized -E pipeline --ignore test/output test
+commands = pylint -f colorized -E pipeline
 
 [testenv:devenv]
 skipdist = True


### PR DESCRIPTION
This is causing a build failure currently. We should figure out how
to enable it later. Per @michaelbausor, we probably never were
actually linting it; it was being ignored until a pylint update caused
it to become an error.