### PR TITLE
Fix bugs in Python GRPC/Gapic package publishing

### DIFF
--- a/pipeline/pipelines/gapic_generation_pipeline.py
+++ b/pipeline/pipelines/gapic_generation_pipeline.py
@@ -91,8 +91,6 @@ class _RubyGapicTaskFactory(GapicTaskFactoryBase):
     def _get_gapic_package_tasks(self, **kwargs):
         return [gapic_tasks.GapicMergeTask('GapicMerge', inject=kwargs),
                 gapic_tasks.GapicPackmanTask('GapicPackman', inject=kwargs),
-                package_tasks.GapicPackageDirTask('PackageDir',
-                                                  inject=kwargs),
                 package_tasks.RubyPackageGenTask('GapicPackageGen',
                                                  inject=kwargs)]
 

--- a/pipeline/pipelines/grpc_generation_pipeline.py
+++ b/pipeline/pipelines/grpc_generation_pipeline.py
@@ -42,7 +42,6 @@ class _RubyGrpcTaskFactory(GrpcTaskFactoryBase):
 
     def get_tasks(self, **kwargs):
         return [protoc_tasks.GrpcPackmanTask('Packman', inject=kwargs),
-                package_tasks.GrpcPackageDirTask('PackageDir', inject=kwargs),
                 package_tasks.RubyPackageGenTask('GrpcPackageGen',
                                                  inject=kwargs)]
 

--- a/pipeline/tasks/gapic_tasks.py
+++ b/pipeline/tasks/gapic_tasks.py
@@ -157,6 +157,8 @@ class GapicMergeTask(task_base.TaskBase):
 
 
 class GapicPackmanTask(packman_tasks.PackmanTaskBase):
+    default_provides = 'package_dir'
+
     def execute(self, language, api_name, final_repo_dir):
         # Some APIs will be a part of gcloud project for Ruby and NodeJS.
         # Such APIs don't need packman.
@@ -168,3 +170,4 @@ class GapicPackmanTask(packman_tasks.PackmanTaskBase):
                          task_utils.packman_api_name(api_name),
                          '--gax_dir=' + final_repo_dir,
                          '--template_root=templates/gax')
+        return final_repo_dir

--- a/pipeline/tasks/package_tasks.py
+++ b/pipeline/tasks/package_tasks.py
@@ -39,25 +39,3 @@ class RubyPackageGenTask(task_base.TaskBase):
 
     def validate(self):
         return [ruby_requirements.RakeRequirements]
-
-
-class GrpcPackageDirTask(task_base.TaskBase):
-    """Bring 'package_dir' parameter for gRPC code generation pipeline.
-
-    This assumes that gRPC client is generated through packman, which generates
-    the files under output/language.
-    """
-
-    default_provides = 'package_dir'
-
-    def execute(self, language, output_dir):
-        return os.path.join(output_dir, language)
-
-
-class GapicPackageDirTask(task_base.TaskBase):
-    """Bring 'package_dir' parameter for Gapic code generation pipeline."""
-
-    default_provides = 'package_dir'
-
-    def execute(self, final_repo_dir):
-        return final_repo_dir

--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -333,6 +333,8 @@ class GoLangUpdateImportsTask(task_base.TaskBase):
 
 
 class GrpcPackmanTask(packman_tasks.PackmanTaskBase):
+    default_provides = 'package_dir'
+
     def execute(self, language, api_name, output_dir, src_proto_path,
                 import_proto_path, packman_flags=None, repo_dir=None):
         packman_flags = packman_flags or []
@@ -351,6 +353,7 @@ class GrpcPackmanTask(packman_tasks.PackmanTaskBase):
         if repo_dir:
             arg_list += ['-r', repo_dir]
         self.run_packman(*arg_list)
+        return os.path.join(pkg_dir, language)
 
 
 class GoExtractImportBaseTask(task_base.TaskBase):

--- a/test/testdata/java_core_proto_pub_pipeline.baseline
+++ b/test/testdata/java_core_proto_pub_pipeline.baseline
@@ -1,2 +1,2 @@
 gen-api-package --api_name=library/v1 -l java -o {OUTPUT}/library-v1-gen-java --package_prefix grpc- -i {CWD}/test/fake-repos/gapi-core-proto/src/main/proto -r test/fake-repos/fake-proto --experimental_alt_java --build_common_protos
-{OUTPUT}/final/gradlew uploadArchives -PmavenRepoUrl=http://maven.example.com/nexus/content/repositories/releases -PmavenUsername=example-maven-uname -PmavenPassword=example-maven-pwd -p{OUTPUT}/final
+{OUTPUT}/library-v1-gen-java/java/gradlew uploadArchives -PmavenRepoUrl=http://maven.example.com/nexus/content/repositories/releases -PmavenUsername=example-maven-uname -PmavenPassword=example-maven-pwd -p{OUTPUT}/library-v1-gen-java/java

--- a/test/testdata/java_grpc_client_pub_pipeline.baseline
+++ b/test/testdata/java_grpc_client_pub_pipeline.baseline
@@ -1,2 +1,2 @@
 gen-api-package --api_name=library/v1 -l java -o {OUTPUT}/library-v1-gen-java --package_prefix grpc- -i {CWD}/test/fake-repos/gapi-core-proto/src/main/proto -r test/fake-repos/fake-proto --experimental_alt_java
-{OUTPUT}/final/gradlew uploadArchives -PmavenRepoUrl=http://maven.example.com/nexus/content/repositories/releases -PmavenUsername=example-maven-uname -PmavenPassword=example-maven-pwd -p{OUTPUT}/final
+{OUTPUT}/library-v1-gen-java/java/gradlew uploadArchives -PmavenRepoUrl=http://maven.example.com/nexus/content/repositories/releases -PmavenUsername=example-maven-uname -PmavenPassword=example-maven-pwd -p{OUTPUT}/library-v1-gen-java/java

--- a/test/testdata/python_grpc_client_pub_pipeline.baseline
+++ b/test/testdata/python_grpc_client_pub_pipeline.baseline
@@ -1,4 +1,4 @@
 gen-api-package --api_name=library/v1 -l python -o {OUTPUT}/library-v1-gen-python --package_prefix grpc- -i {CWD}/test/fake-repos/gapi-core-proto/src/main/proto -r test/fake-repos/fake-proto
 devpi login --password example-pwd example-user
 devpi use https://example-site.exampledomain.com/example-user/dev
-devpi upload --no-vcs --from-dir {OUTPUT}/final
+devpi upload --no-vcs


### PR DESCRIPTION
devpi upload failed during manual test by Jacob because the --from-dir
flag for "devpi upload" requires archive files
(see http://doc.devpi.net/latest/userman/devpi_commands.html#upload).
Had subprocess change into ouptut directory before running "devpi
upload".

Also deleted the GrpcPackageDirTask and GapicPackageDirTask
from package_tasks: now package_dir is set by GrpcPackmanTask or
GapicPackmanTask with the default_provides keyword. Maven and PyPI
upload is now done from package_dir rather than final_repo_dir.

Also made a trailing slash for repo_url optional.