### PR TITLE
Add requirements into seteup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ requirements = [
     'oslo.utils>=3.4.0',
     'pyyaml>=3.11',
     'taskflow>=1.25.0,<2.0.0',
-    'yapf>=0.6.2'
+    'yapf>=0.6.2',
+    'google-apitools',
+    'requests>=2.10.0,<3.0.0'
 ]
 
 setuptools.setup(


### PR DESCRIPTION
pip install command looks up the requirements listed here.
Thus sometimes it will fail to install some dependencies when
the user installs artman through pip-install command.