### PR TITLE
Use grpcio-tools for Python grpc codegen

### DIFF
--- a/pipeline/pipelines/grpc_generation_pipeline.py
+++ b/pipeline/pipelines/grpc_generation_pipeline.py
@@ -53,6 +53,16 @@ class _JavaGrpcTaskFactory(GrpcTaskFactoryBase):
         return super(_JavaGrpcTaskFactory, self).get_tasks(**kwargs)
 
 
+class _PythonGrpcTaskFactory(GrpcTaskFactoryBase):
+
+    def get_tasks(self, **kwargs):
+        kwargs.update({'packman_flags': ['--proto_compiler',
+                                         'python',
+                                         '--proto_compiler_args',
+                                         '-m grpc.tools.protoc']})
+        return super(_PythonGrpcTaskFactory, self).get_tasks(**kwargs)
+
+
 class _GoGrpcTaskFactory(GrpcTaskFactoryBase):
     """Responsible for the protobuf/gRPC flow for Go language.
 
@@ -84,7 +94,7 @@ class _CSharpGrpcTaskFactory(GrpcTaskFactoryBase):
 
 _GRPC_TASK_FACTORY_DICT = {
     'java': _JavaGrpcTaskFactory,
-    'python': GrpcTaskFactoryBase,
+    'python': _PythonGrpcTaskFactory,
     'go': _GoGrpcTaskFactory,
     'ruby': _RubyGrpcTaskFactory,
     'php': GrpcTaskFactoryBase,

--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -117,7 +117,6 @@ class _PhpProtoParams:
 
 
 _PROTO_PARAMS_MAP = {
-    'python': _SimpleProtoParams('python'),
     'ruby': _SimpleProtoParams('ruby'),
     'java': _JavaProtoParams(),
     'go': _GoProtoParams(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ taskflow==1.25.0
 kazoo>=2.2.1
 google-apitools
 gcloud==0.15.0
+grpcio-tools>=1.0.0
 yapf>=0.6.2 # Apache-2.0
 requests>=2.10.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from pip.req import parse_requirements
 
 requirements = [
     'gcloud>=0.10.0',
+    'grpcio-tools>=1.0.0',
     'kazoo>=2.2.1',
     'oslo.utils>=3.4.0',
     'pyyaml>=3.11',


### PR DESCRIPTION
Currently, we use protoc and grpc_python_plugin binaries installed
by linuxbrew (see the Dockerfile); however, these are deprecated for
Python and produce grpc 1.0-incompatible codegen.

Instead, use the officially-supported grpcio-tools Python executable
module; install this via tox, rather than linuxbrew.

NOTE: DO NOT MERGE until grpc/grpc#7857 is resolved.