### PR TITLE
Improve error reporting for bad local_repo

### DIFF
--- a/pipeline/tasks/io_tasks.py
+++ b/pipeline/tasks/io_tasks.py
@@ -87,8 +87,7 @@ class PrepareUploadDirTask(task_base.TaskBase):
             raise ValueError(
                 'Size of merged local_repo was {}, exceeding the limit of {} '
                 'bytes; reduce the size of local_repo'.format(
-                    size,
-                    _ZOOKEEPER_NODE_DATA_SIZE_LIMIT))
+                    size, _ZOOKEEPER_NODE_DATA_SIZE_LIMIT))
 
 
 class CleanupTempDirsTask(task_base.TaskBase):

--- a/pipeline/tasks/io_tasks.py
+++ b/pipeline/tasks/io_tasks.py
@@ -74,6 +74,14 @@ class BlobDownloadTask(task_base.TaskBase):
             print 'File downloaded to %s' % f.name
 
 
+def _validate_upload_size(size, limit):
+    if size > limit:
+        raise ValueError(
+            'Zipped size of merged local_repo is {}, exceeding the limit '
+            'of {} bytes; reduce the size of local_repo'.format(
+                size, limit))
+
+
 class PrepareUploadDirTask(task_base.TaskBase):
     """Compress pipeline dir_to_upload into a file which can be uploaded to GCS.
 
@@ -82,12 +90,8 @@ class PrepareUploadDirTask(task_base.TaskBase):
 
     def execute(self, repo_root, tarfile):
         self.exec_command(['tar', '-C', repo_root, '-zcvf', tarfile, '.'])
-        size = os.path.getsize(tarfile)
-        if size > _ZOOKEEPER_NODE_DATA_SIZE_LIMIT:
-            raise ValueError(
-                'Size of merged local_repo was {}, exceeding the limit of {} '
-                'bytes; reduce the size of local_repo'.format(
-                    size, _ZOOKEEPER_NODE_DATA_SIZE_LIMIT))
+        _validate_upload_size(
+            os.path.getsize(tarfile), _ZOOKEEPER_NODE_DATA_SIZE_LIMIT)
 
 
 class CleanupTempDirsTask(task_base.TaskBase):

--- a/pipeline/tasks/io_tasks.py
+++ b/pipeline/tasks/io_tasks.py
@@ -26,7 +26,7 @@ from pipeline.tasks import task_base
 
 # Maximum amount of data, in bytes, that can be stored in a zookeeper node. See
 # http://zookeeper.apache.org/doc/r3.1.2/api/org/apache/zookeeper/ZooKeeper.html
-_ZOOKEEPER_NODE_DATA_SIZE_LIMIT = 1048576
+_ZOOKEEPER_NODE_DATA_SIZE_LIMIT = 2 ** 20
 
 
 class BlobUploadTask(task_base.TaskBase):
@@ -129,7 +129,9 @@ class PrepareGoogleapisDirTask(task_base.TaskBase):
             with open(filename, "w+") as text_file:
                 text_file.write(base64.b64decode(content))
         if total_bytes > _ZOOKEEPER_NODE_DATA_SIZE_LIMIT:
-            raise ValueError('size of merged local_repo exceeds limit of {} '
-                             'bytes; reduce the size of local_repo'.format(
-                                 _ZOOKEEPER_NODE_DATA_SIZE_LIMIT))
+            raise ValueError(
+                'Size of merged local_repo was {}, exceeding the limit of {} '
+                'bytes; reduce the size of local_repo'.format(
+                    total_bytes,
+                    _ZOOKEEPER_NODE_DATA_SIZE_LIMIT))
         return repo_dir

--- a/test/test_io_tasks.py
+++ b/test/test_io_tasks.py
@@ -1,0 +1,17 @@
+import unittest
+
+from pipeline.tasks import io_tasks
+
+
+_UPLOAD_LIMIT = 123
+
+
+class ValidateUploadSizeTest(unittest.TestCase):
+
+    def test_validate_upload_size_ok(self):
+        io_tasks._validate_upload_size(_UPLOAD_LIMIT, _UPLOAD_LIMIT)
+
+    def test_validate_upload_size_bad(self):
+        self.assertRaises(
+            ValueError, io_tasks._validate_upload_size,
+            _UPLOAD_LIMIT + 1, _UPLOAD_LIMIT)

--- a/test/test_io_tasks.py
+++ b/test/test_io_tasks.py
@@ -1,3 +1,17 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from pipeline.tasks import io_tasks


### PR DESCRIPTION
Previously, a confusing error occurred remotely if the local_repo was
too big. Instead, validate the size locally and raise a meaningful
exception.

Fixes #74 