### PR TITLE
Don't assume string exists during macro expansion

### DIFF
--- a/execute_pipeline.py
+++ b/execute_pipeline.py
@@ -205,6 +205,8 @@ def _var_replace_config_data(data, repl_vars):
 
 
 def _var_replace(in_str, repl_vars):
+    if not in_str:
+        return
     new_str = in_str
     for (k, v) in repl_vars.iteritems():
         new_str = new_str.replace('${' + k + '}', v)


### PR DESCRIPTION
This allows artman to process incomplete configs as in
https://github.com/googleapis/googleapis/pull/104