### PR TITLE
Remove THISDIR macro expansion

### DIFF
--- a/pipeline/utils/config_util.py
+++ b/pipeline/utils/config_util.py
@@ -16,7 +16,6 @@
 """Utils related to config files"""
 
 
-import os
 import yaml
 
 
@@ -33,9 +32,7 @@ def load_config_spec(config_spec, config_sections, repl_vars, language):
     if language in all_config_data:
         data.update(all_config_data[language])
 
-    repl_vars['THISDIR'] = os.path.dirname(config_path)
     var_replace_config_data(data, repl_vars)
-    del repl_vars['THISDIR']
     return data
 
 

--- a/test/test_pipeline_baseline.py
+++ b/test/test_pipeline_baseline.py
@@ -111,7 +111,7 @@ def _test_baseline(pipeline_name, config, extra_args, baseline,
     # Run pipeline
     execute_pipeline.main(args)
 
-    bindings = {'CWD': os.getcwd(), 'OUTPUT': output_dir}
+    bindings = {'CWD': reporoot, 'OUTPUT': output_dir}
 
     # Compare with the expected subprocess calls.
     expected_checked_calls = get_expected_calls(

--- a/test/testdata/googleapis_test/gapic/api/artman_library.yaml
+++ b/test/testdata/googleapis_test/gapic/api/artman_library.yaml
@@ -9,9 +9,9 @@ common:
   src_proto_path:
     - test/fake-repos/fake-proto
   service_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/library.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/library.yaml
   gapic_api_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/library_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/library_gapic.yaml
   output_dir: ${REPOROOT}/test/testdata/test_output
   enable_batch_generation: True
 java:

--- a/test/testdata/googleapis_test/gapic/lang/common.yaml
+++ b/test/testdata/googleapis_test/gapic/lang/common.yaml
@@ -4,22 +4,22 @@ common:
   enable_batch_generation: True
 java:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/java_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/java_gapic.yaml
 python:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/python_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/python_gapic.yaml
 go:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/go_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/go_gapic.yaml
 csharp:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/csharp_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/csharp_gapic.yaml
 php:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/php_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/php_gapic.yaml
 ruby:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/ruby_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/ruby_gapic.yaml
 nodejs:
   gapic_language_yaml:
-    - ${THISDIR}/../../../gapi-example-library-proto/src/main/proto/google/example/library/nodejs_gapic.yaml
+    - ${REPOROOT}/test/testdata/gapi-example-library-proto/src/main/proto/google/example/library/nodejs_gapic.yaml


### PR DESCRIPTION
- THISDIR is no longer used in the real googleapis
- THISDIR causes problems when running in remote mode
- [geigerj/artman wrapper branch](https://github.com/geigerj/artman/tree/wrapper) relies on this change, but it's not directly related to the wrapper, so it seems good to separate it into its own PR.

Fixes #93