### PR TITLE
Pass skip_packman as a pipeline_arg

### DIFF
--- a/pipeline/tasks/gapic_tasks.py
+++ b/pipeline/tasks/gapic_tasks.py
@@ -130,11 +130,8 @@ class GapicCopyTask(task_base.TaskBase):
 class GapicPackmanTask(packman_tasks.PackmanTaskBase):
     default_provides = 'package_dir'
 
-    def execute(self, language, api_name, final_repo_dir):
-        # Some APIs will be a part of gcloud project for Ruby and NodeJS.
-        # Such APIs don't need packman.
-        if ((language != 'ruby' and language != 'nodejs') or
-                not task_utils.is_output_gcloud(language, final_repo_dir)):
+    def execute(self, language, api_name, final_repo_dir, skip_packman=False):
+        if not skip_packman:
             # TODO: Use TaskBase.exec_command()
             self.run_packman(language,
                              task_utils.packman_api_name(api_name),


### PR DESCRIPTION
Formerly, packman was skipped for all Ruby/NodeJS Cloud GAPIC packages.
Actually, some packages require packman; the correct condtion is that
packman should be skipped if there is a handwritten layer on top of
GAPIC. This should be configured per-API instead of hard-coded into
artman.

Fixes #95 