### PR TITLE
Turn gRPC codegen back on for Python

### DIFF
--- a/pipeline/pipelines/grpc_generation_pipeline.py
+++ b/pipeline/pipelines/grpc_generation_pipeline.py
@@ -63,7 +63,7 @@ class _PythonGrpcTaskFactory(GrpcTaskFactoryBase):
     def _get_grpc_codegen_tasks(self, **kwargs):
         return [python_grpc_tasks.PythonChangePackageTask,
                 protoc_tasks.ProtoDescGenTask,
-                protoc_tasks.ProtoCodeGenTask,
+                protoc_tasks.ProtoAndGrpcCodeGenTask,
                 protoc_tasks.GrpcPackageMetadataGenTask]
 
 

--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -175,7 +175,7 @@ class _PythonProtoParams:
         return None
 
     def grpc_out_param(self, output_dir):
-        return '--grpc_out=' + self.code_root(output_dir)
+        return '--grpc_python_out=' + self.code_root(output_dir)
 
     @property
     def proto_compiler_command(self):
@@ -234,11 +234,9 @@ def _protoc_proto_params(proto_params, pkg_dir, with_grpc):
 
 
 def _protoc_grpc_params(proto_params, pkg_dir, toolkit_path):
-    plugin_path = proto_params.grpc_plugin_path(toolkit_path)
-    if plugin_path is None:
-        return []
-    return ['--plugin=protoc-gen-grpc=' + plugin_path,
-            proto_params.grpc_out_param(pkg_dir)]
+    plugin_param = proto_params.grpc_plugin_path(toolkit_path)
+    grpc_param = proto_params.grpc_out_param(pkg_dir)
+    return [param for param in (plugin_param, grpc_param) if param]
 
 
 def _pkg_root_dir(output_dir, api_name, language):

--- a/test/testdata/csharp_grpc_client_pipeline.baseline
+++ b/test/testdata/csharp_grpc_client_pipeline.baseline
@@ -2,4 +2,4 @@ mkdir -p {OUTPUT}/library-v1-gen-csharp
 protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --csharp_out={OUTPUT}/library-v1-gen-csharp test/fake-repos/fake-proto/fake.proto
 mkdir -p {OUTPUT}/library-v1-gen-csharp
 which grpc_csharp_plugin
-protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --plugin=protoc-gen-grpc= --grpc_out={OUTPUT}/library-v1-gen-csharp test/fake-repos/fake-proto/fake.proto
+protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --grpc_out={OUTPUT}/library-v1-gen-csharp test/fake-repos/fake-proto/fake.proto

--- a/test/testdata/ruby_grpc_client_pipeline.baseline
+++ b/test/testdata/ruby_grpc_client_pipeline.baseline
@@ -1,6 +1,6 @@
 mkdir -p {OUTPUT}/library-v1-gen-ruby
 which grpc_ruby_plugin
-grpc_tools_ruby_protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --ruby_out={OUTPUT}/library-v1-gen-ruby --plugin=protoc-gen-grpc= --grpc_out={OUTPUT}/library-v1-gen-ruby test/fake-repos/fake-proto/fake.proto
+grpc_tools_ruby_protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --ruby_out={OUTPUT}/library-v1-gen-ruby --grpc_out={OUTPUT}/library-v1-gen-ruby test/fake-repos/fake-proto/fake.proto
 mkdir -p {OUTPUT}/final/lib
 cp -rf {OUTPUT}/library-v1-gen-ruby/library_pb.rb {OUTPUT}/final/lib
 cp -rf {OUTPUT}/library-v1-gen-ruby/my_api_services_pb.rb {OUTPUT}/final/lib


### PR DESCRIPTION
It was accidentally removed in #115.

Note that this change removes an flag that set the protoc gRPC plugin
to an empty value for Ruby and C#; presumably removing the empty flag
will have no effect.

FYI @swcloud @chrisdunelm regarding the modification to the Ruby/C# gRPC codegen command; see the baseline file change for details.