### PR TITLE
Fix typo in plugin param

### DIFF
--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -234,9 +234,14 @@ def _protoc_proto_params(proto_params, pkg_dir, with_grpc):
 
 
 def _protoc_grpc_params(proto_params, pkg_dir, toolkit_path):
+    params = []
     plugin_param = proto_params.grpc_plugin_path(toolkit_path)
+    if plugin_param:
+        params.append('--plugin=protoc-gen-grpc={}'.format(plugin_param))
     grpc_param = proto_params.grpc_out_param(pkg_dir)
-    return [param for param in (plugin_param, grpc_param) if param]
+    if grpc_param:
+        params.append(grpc_param)
+    return params
 
 
 def _pkg_root_dir(output_dir, api_name, language):


### PR DESCRIPTION
#116 actually removed the flag name from the grpc plugin param. ~~I didn't notice this because no language is currently passing a grpc plugin to protoc directly.~~

EDIT: this fixes a breakage in the Ruby gRPC pipeline. #119 filed for why the baseline tests don't reflect that.