### PR TITLE
Remove Ruby gRPC plugin

### DIFF
--- a/pipeline/tasks/protoc_tasks.py
+++ b/pipeline/tasks/protoc_tasks.py
@@ -145,11 +145,8 @@ class _RubyProtoParams:
         return '--ruby_out={}'.format(self.code_root(output_dir))
 
     def grpc_plugin_path(self, dummy_toolkit_path):
-        if self.path is None:
-            self.path = subprocess.check_output(
-                ['which', 'grpc_ruby_plugin'],
-                stderr=subprocess.STDOUT)[:-1]
-        return self.path
+        # No plugin for grpc_toos_ruby_protoc
+        return None
 
     def grpc_out_param(self, output_dir):
         return '--grpc_out=' + self.code_root(output_dir)

--- a/test/testdata/ruby_grpc_client_pipeline.baseline
+++ b/test/testdata/ruby_grpc_client_pipeline.baseline
@@ -1,5 +1,4 @@
 mkdir -p {OUTPUT}/library-v1-gen-ruby
-which grpc_ruby_plugin
 grpc_tools_ruby_protoc --proto_path=test/fake-repos/gapi-core-proto/src/main/proto/ --proto_path=test/fake-repos/fake-proto --proto_path=MOCK_GRADLE_TASK_OUTPUT --ruby_out={OUTPUT}/library-v1-gen-ruby --grpc_out={OUTPUT}/library-v1-gen-ruby test/fake-repos/fake-proto/fake.proto
 mkdir -p {OUTPUT}/final/lib
 cp -rf {OUTPUT}/library-v1-gen-ruby/library_pb.rb {OUTPUT}/final/lib


### PR DESCRIPTION
Ruby gRPC plugin is not used with the Ruby protoc package.