### PR TITLE
Don't dump Python classes in package metadata YAML

### DIFF
--- a/pipeline/tasks/package_metadata_tasks.py
+++ b/pipeline/tasks/package_metadata_tasks.py
@@ -60,7 +60,7 @@ class PackageMetadataConfigGenTask(task_base.TaskBase):
     # Separated so that this can be mocked for testing
     def _write_yaml(self, config_dict, dest):
         with open(dest, 'w') as f:
-            yaml.dump(config_dict, f, default_flow_style=False)
+            yaml.safe_dump(config_dict, f, default_flow_style=False)
 
 
 class GrpcPackageMetadataGenTask(task_base.TaskBase):


### PR DESCRIPTION
A user running remote artman encountered a failure where artman dumped
a `!!python/unicode 'v1beta1'` object in the package metadata. This
caused an error when the `toolkit` Java code tried to load the yaml file.

Use `safe_dump` instead of `dump` to ensure that Python objects are
not being dumped in the package metadata.