### PR TITLE
Inroduce kubenetes deployment yamls for dev and prod environments. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,4 +93,3 @@ ADD . /src
 WORKDIR /src
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
-CMD python start_conductor.py

--- a/k8s/README.rst
+++ b/k8s/README.rst
@@ -1,0 +1,8 @@
+# Running artman as a service on Kubernetes
+
+Artman can be run as a remote service (AaaS) to receive and execute artifact
+generation requests. While it can be run anywhere, it can run more easily
+on Kubernetes (k8s), via the config files in this folder.
+
+Note: this is an experimental feature, which is used by whitelisted developers
+at this moment. We will make it open to everyone very soon.

--- a/k8s/dev/dev.yaml
+++ b/k8s/dev/dev.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: dev
+  name: dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: dev
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: dev
+    spec:
+      containers:
+      - image: gcr.io/vkit-pipeline/github-googleapis-artman:latest
+        imagePullPolicy: Always
+        name: dev
+        resources: {}
+        command: ["python"]
+        args: ["start_conductor.py",  "--jobboard_name=dev"]
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}

--- a/k8s/prod/prod.yaml
+++ b/k8s/prod/prod.yaml
@@ -1,0 +1,31 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: prod
+  name: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: prod
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: prod
+    spec:
+      containers:
+      - image: gcr.io/vkit-pipeline/github-googleapis-artman:stable
+        imagePullPolicy: Always
+        name: prod
+        resources: {}
+        command: ["python"]
+        args: ["start_conductor.py",  "--jobboard_name=remote"]
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}


### PR DESCRIPTION
Start the artman conductor as part of the deployment file instead of Dockerfile.