### PR TITLE
Include a default artman user config in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,10 @@ ADD . /src
 WORKDIR /src
 RUN pip install -e .
 
+# Setup artman user config
+RUN mkdir /root/.artman
+ADD artman-user-config-in-docker.yaml /root/.artman/config.yaml
+
 # Run smoketests
 # TODO(ethanbao): this should be part of artman CI.
 RUN python test/smoketest.py

--- a/artman-user-config-in-docker.yaml
+++ b/artman-user-config-in-docker.yaml
@@ -1,0 +1,4 @@
+---
+local_paths:
+  reporoot: /
+publish: noop


### PR DESCRIPTION
Include a default artman user config in the docker image so that there will be no need to setup artman config in the docker image.