### PR TITLE
Turn NodeJS gRPC client pipeline into a no-op

### DIFF
--- a/artman/pipelines/grpc_generation.py
+++ b/artman/pipelines/grpc_generation.py
@@ -151,6 +151,11 @@ class _CSharpGrpcTaskFactory(GrpcTaskFactoryBase):
             protoc_tasks.GrpcCodeGenTask,
         ]
 
+class _NodeJsGrpcTaskFactory(GrpcTaskFactoryBase):
+
+    def get_grpc_codegen_tasks(self, **kwargs):
+        return []
+
 
 GRPC_TASK_FACTORY_DICT = {
     'java': _JavaGrpcTaskFactory,
@@ -159,7 +164,7 @@ GRPC_TASK_FACTORY_DICT = {
     'ruby': _RubyGrpcTaskFactory,
     'php': GrpcTaskFactoryBase,
     'csharp': _CSharpGrpcTaskFactory,
-    'nodejs': GrpcTaskFactoryBase,
+    'nodejs': _NodeJsGrpcTaskFactory,
 }
 
 


### PR DESCRIPTION
It was effectively a no-op anyway, since no files generated in the
pipeline were used by the artman config.