### PR TITLE
Fix protos in subdirectories for Python.

### DIFF
--- a/test/golden/artman_library_example_new.yaml
+++ b/test/golden/artman_library_example_new.yaml
@@ -1,5 +1,5 @@
 common:
-  api_name: library_example
+  api_name: library
   api_version: v1
   organization_name: google-cloud
   proto_deps:

--- a/test/golden/library_example_gapic.yaml
+++ b/test/golden/library_example_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.cloud.example.library.spi.v1
   python:
-    package_name: google.cloud.gapic.example.library.v1
+    package_name: google.cloud.example.library_v1.gapic
   go:
     package_name: cloud.google.com/go/example/library/apiv1
   csharp:


### PR DESCRIPTION
This is a theoretically-correct fix for the "protos in subdirectories" problem that Jacob and I discovered on Firestore today.

Note: The GAPIC does not generate the correct path for subdirectory cases (this will be a toolkit bug for @landrito).

Note also: There is at least one semantic change, which is that proto path transformation will not happen cross-API anymore. This is probably okay (we do not rely on this I doubt there was any world where it ever worked) but needs some discussion with @geigerj and @landrito.