### PR TITLE
Fix a bug that mishandles the path to artman config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (C#)
           command: artman --local --config=google/pubsub/artman_pubsub.yaml --root-dir=/googleapis generate csharp_gapic
@@ -166,7 +166,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Go)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging go_gapic
@@ -186,7 +186,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Java)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging java_gapic
@@ -206,7 +206,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Node.js)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging nodejs_gapic
@@ -226,7 +226,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (PHP)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging php_gapic
@@ -246,7 +246,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Python)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging python_gapic
@@ -266,7 +266,7 @@ jobs:
           name: Install latest artman
           command: |
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Ruby)
           command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging ruby_gapic
@@ -287,7 +287,7 @@ jobs:
           command: |
             pip install pytest
             pip uninstall -y googleapis-artman
-            pip install --upgrade /usr/src/artman/
+            pip install --upgrade -e /usr/src/artman/
             git clone https://github.com/googleapis/googleapis /usr/src/artman/test/golden/googleapis
       - run:
           name: Run golden test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,10 +149,10 @@ jobs:
             pip install --upgrade /usr/src/artman/
       - run:
           name: Build Pub/Sub (C#)
-          command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml generate csharp_gapic
+          command: artman --local --config=google/pubsub/artman_pubsub.yaml --root-dir=/googleapis generate csharp_gapic
       - run:
           name: Build Speech (C#)
-          command: artman --local --config=/googleapis/google/cloud/speech/artman_speech_v1.yaml generate csharp_gapic
+          command: artman --local --config=google/cloud/speech/artman_speech_v1.yaml --root-dir=/googleapis generate csharp_gapic
     working_directory: /usr/src/artman/
 
   smoke-go:

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -279,7 +279,6 @@ def normalize_flags(flags, user_config):
     else:
         flags.config = os.path.abspath(flags.config)
     flags.output_dir = os.path.abspath(flags.output_dir)
-    flags.config = os.path.abspath(flags.config)
     pipeline_args = {}
 
     # Determine logging verbosity and then set up logging.

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -275,6 +275,9 @@ def normalize_flags(flags, user_config):
     """
     if flags.root_dir:
         flags.root_dir = os.path.abspath(flags.root_dir)
+        flags.config = os.path.join(flags.root_dir, flags.config)
+    else:
+        flags.config = os.path.abspath(flags.config)
     flags.output_dir = os.path.abspath(flags.output_dir)
     flags.config = os.path.abspath(flags.config)
     pipeline_args = {}


### PR DESCRIPTION
Besides `pip install --upgrade` alone doesn't seem to reinstall artman without `-e`.