### PR TITLE
 Introduce optional --local-repo-dir subflag to `publish --dry-run` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,9 @@ jobs:
             pip install --upgrade -e /usr/src/artman/
       - run:
           name: Build Pub/Sub (Java)
-          command: artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --github-username foo --github-token bar --target staging java_gapic
+          command: |
+            git clone https://github.com/googleapis/api-client-staging /tmp/api-client-staging
+            artman --local --config=/googleapis/google/pubsub/artman_pubsub.yaml publish --dry-run --local-repo-dir=/tmp/api-client-staging --github-username foo --github-token bar --target staging java_gapic
       - run:
           name: Build Speech (Java)
           command: artman --local --config=/googleapis/google/cloud/speech/artman_speech_v1.yaml publish --dry-run --github-username foo --github-token bar --target staging java_gapic

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -234,7 +234,7 @@ def parse_args(*args):
         help='[Optional] When specified, artman will neither look up the '
         'publishing configuration in ~/.artman.config.yaml, nor clone a new '
         'github repo. Instead, it will use the specified directory to stage '
-        'generated result. This only work under dry run mode.', )
+        'generated result. This only works under --dry-run mode.', )
     parser_publish.set_defaults(dry_run=False)
 
     return parser.parse_args(args=args)

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -231,10 +231,10 @@ def parse_args(*args):
         '--local-repo-dir',
         type=str,
         default=None,
-        help='[Optional] When specified, artman will skip the lookup local '
+        help='[Optional] When specified, artman will neither look up the '
         'publishing configuration in ~/.artman.config.yaml, nor clone a new '
         'github repo. Instead, it will use the specified directory to stage '
-        'generated result. This is only working when under dry run mode.', )
+        'generated result. This only work under dry run mode.', )
     parser_publish.set_defaults(dry_run=False)
 
     return parser.parse_args(args=args)
@@ -510,7 +510,7 @@ def _run_artman_in_docker(flags):
 
 
 def _change_owner(flags, pipeline_name, pipeline_kwargs):
-    """Change file/folder ownership if necessary."""
+    """Change file/directory ownership if necessary."""
     user_host_id = int(os.getenv('HOST_USER_ID', 0))
     group_host_id = int(os.getenv('HOST_GROUP_ID', 0))
     # When artman runs in Docker instance, all output files are by default
@@ -522,13 +522,13 @@ def _change_owner(flags, pipeline_name, pipeline_kwargs):
         return
     # Change ownership of output directory.
     if os.path.exists(flags.output_dir):
-        _change_folder_owner(flags.output_dir, user_host_id, group_host_id)
+        _change_directory_owner(flags.output_dir, user_host_id, group_host_id)
 
     # Change the local repo directory if specified.
     if 'local_repo_dir' in pipeline_kwargs:
         local_repo_dir = pipeline_kwargs['local_repo_dir']
         if (os.path.exists(local_repo_dir)):
-            _change_folder_owner(local_repo_dir, user_host_id, group_host_id)
+            _change_directory_owner(local_repo_dir, user_host_id, group_host_id)
 
     if pipeline_kwargs['gapic_api_yaml']:
         gapic_config_path = pipeline_kwargs['gapic_api_yaml'][0]
@@ -537,14 +537,14 @@ def _change_owner(flags, pipeline_name, pipeline_kwargs):
             # There is a trick that the gapic config output is generated to
             # input directory, where it is supposed to be in order to be
             # used as an input for other artifact generation. With that
-            # the gapic config output is not located in the output folder,
-            # but the input folder. Make the explicit chown in this case.
+            # the gapic config output is not located in the output directory,
+            # but the input directory. Make the explicit chown in this case.
             os.chown(gapic_config_path, user_host_id, group_host_id)
 
 
-def _change_folder_owner(folder, user_host_id, group_host_id):
-    """Change ownership recursively for everything under the given folder."""
-    for root, dirs, files in os.walk(folder):
+def _change_directory_owner(directory, user_host_id, group_host_id):
+    """Change ownership recursively for everything under the given directory."""
+    for root, dirs, files in os.walk(directory):
         os.chown(root, user_host_id, group_host_id)
         for d in dirs:
             os.chown(

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -299,7 +299,7 @@ def normalize_flags(flags, user_config):
     pipeline_args['local_paths'] = support.parse_local_paths(
         user_config, flags.root_dir)
 
-    if flags.local_repo_dir:
+    if flags.subcommand == 'publish' and flags.local_repo_dir:
         if not flags.dry_run:
             logger.error('`--dry-run` flag must be passed when '
                          '`--local-repo-dir` is specified')

--- a/artman/tasks/publish/local.py
+++ b/artman/tasks/publish/local.py
@@ -31,7 +31,8 @@ class LocalStagingTask(task_base.TaskBase):
     This task requires WRITE access to the applicable repository.
     """
     def execute(self, git_repo, local_paths, output_dir,
-        gapic_code_dir=None, grpc_code_dir=None, proto_code_dir=None):
+        gapic_code_dir=None, grpc_code_dir=None, proto_code_dir=None,
+        local_repo_dir=None):
         """Copy the code to the correct local staging location.
 
         Args:
@@ -51,12 +52,16 @@ class LocalStagingTask(task_base.TaskBase):
         if repo_name.endswith('.git'):
             repo_name = repo_name[:-4]
 
-        # Where is the target git repo located?
-        # Start by checking for an explicit path in `local_paths`, and then
-        # if none is found, clone the repo to output_dir.
+        # Artman will find the local repo dir in the following order:
+        # 1. Check whether an explicit `--local_repo_dir` flag is passed.
+        # 2. Check whether a matched local repo dir is specified in user config.
+        # 3. Clones the repo to output_dir, and use the cloned repo dir.
         repo_name_underscore = repo_name.replace('-', '_')
-        api_repo = local_paths.get(repo_name_underscore)
-        if not api_repo:
+        if local_repo_dir:
+            api_repo = local_repo_dir
+        elif local_paths.get(repo_name_underscore):
+            api_repo = local_paths.get(repo_name_underscore)
+        else:
             api_repo = os.path.join(output_dir, repo_name)
             if os.path.exists(api_repo):
                 logger.fatal(

--- a/artman/tasks/publish/local.py
+++ b/artman/tasks/publish/local.py
@@ -52,9 +52,11 @@ class LocalStagingTask(task_base.TaskBase):
         if repo_name.endswith('.git'):
             repo_name = repo_name[:-4]
 
-        # Artman will find the local repo dir in the following order:
-        # 1. Check whether an explicit `--local_repo_dir` flag is passed.
+        # Artman will find the local repo dir via the following steps:
+        # 1. Check whether an explicit `--local_repo_dir` flag is passed. Is so,
+        #    use that value.
         # 2. Check whether a matched local repo dir is specified in user config.
+        #    If so, use that value.
         # 3. Clones the repo to output_dir, and use the cloned repo dir.
         repo_name_underscore = repo_name.replace('-', '_')
         if local_repo_dir:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ google-apitools
 gcloud >= 0.15.0
 github3.py >= 0.9.6
 google-api-python-client >= 1.6.2
+msgpack-python >= 0.4.1, < 0.5.0
 networkx == 1.11.0
 kazoo >= 2.2.1
 oslo.utils >= 3.4.0

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -97,7 +97,8 @@ class NormalizeFlagTests(unittest.TestCase):
             github_username='test', github_token='token',
             artifact_name='python_gapic',
             output_dir='./artman-genfiles',
-            dry_run=False
+            dry_run=False,
+            local_repo_dir=None,
         )
         self.user_config = {
             'local_paths': {'reporoot': os.path.realpath('..')},


### PR DESCRIPTION
Introduce optional --local-repo-dir subflag to `publish --dry-run` command, which points to a local github repo directory, that will then be mounted to docker container. Then google-cloud-java team can easily write a 20-line python script (excluding constant string list pointing to different artman yaml) to do batch refresh. And any customization, if necessary, can be done in the repo-specific batch script without coupling with artman.