### PR TITLE
 Introduce --toolkit-dir to override toolkit directory during coding

### DIFF
--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -264,7 +264,8 @@ def normalize_flags(flags, user_config):
     """Combine the argparse flags and user configuration together.
 
     Args:
-        flags (argparse.Namespace): The flags parsed from sys.argv
+        flags (argparse.Namespace): The flags parsed from sys.argv, which may
+                                    be mutated in this function.
         user_config (dict): The user configuration taken from
                             ~/.artman/config.yaml.
 

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -153,6 +153,15 @@ def parse_args(*args):
         'will be raised with instructions.',
     )
     parser.add_argument(
+        '--toolkit-dir',
+        type=str,
+        default='',
+        help='[Optional] Local directory containing the local clone of the '
+        'github/toolkit repo to use, instead of the one specified in the '
+        'configuration files. This flag is useful for testing development '
+        'changes to toolkit via an artman invocation.',
+    )
+    parser.add_argument(
         '-v',
         '--verbose',
         action='store_const',
@@ -397,6 +406,9 @@ def normalize_flags(flags, user_config):
                 'Publishing type `%s` is not supported yet.' %
                 Artifact.PublishTarget.Type.Name(publishing_config.type))
             sys.exit(96)
+
+    if flags.toolkit_dir:
+      pipeline_args['toolkit_path'] = flags.toolkit_dir
 
     # Print out the final arguments to stdout, to help the user with
     # possible debugging.

--- a/artman/config/loader.py
+++ b/artman/config/loader.py
@@ -67,11 +67,11 @@ def _parse(artman_yaml_path):
 
 
 def _validate_artman_config(config_pb):
-    """ Validate the parsed config_pb.
+    """Validate the parsed config_pb.
 
-    Currently, it checkes the uniqueness of the artifact name, and uniqieuness
-    of publishing target name in each artifact. Plus, it makes sure the
-    specified configuration or other input file or folder exists.
+    Currently, it checks the uniqueness of the artifact name and of
+    the publishing target name in each artifact. It also makes sure
+    the specified configuration and input files and directories exist.
     """
     artifacts = set()
     for artifact in config_pb.artifacts:


### PR DESCRIPTION
This allows running the artman command while incorporating changes to a local clone of the googleapis/toolkit repository.