### PR TITLE
Update protoc-gapic-plugin to 0.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kazoo >= 2.2.1
 oslo.utils >= 3.4.0
 pbr==2.0.0
 protobuf >= 3.3.0
-protoc-java-resource-names-plugin >= 0.0.7
+protoc-java-resource-names-plugin >= 0.0.8
 requests >= 2.10.0, < 3.0.0
 ruamel.yaml >= 0.14.5
 six >= 1.10.0


### PR DESCRIPTION
This is needed to generate ResourceName interface methods.