### PR TITLE
Converting gapic_api_yaml/service_yaml to strings internally

### DIFF
--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -454,8 +454,8 @@ def _change_owner(flags, pipeline_name, pipeline_kwargs):
         if (os.path.exists(local_repo_dir)):
             _change_directory_owner(local_repo_dir, user_host_id, group_host_id)
 
-    if pipeline_kwargs['gapic_api_yaml']:
-        gapic_config_path = pipeline_kwargs['gapic_api_yaml'][0]
+    if pipeline_kwargs['gapic_yaml']:
+        gapic_config_path = pipeline_kwargs['gapic_yaml']
         if (os.path.exists(gapic_config_path) and
             ('GapicConfigPipeline' == pipeline_name
                 or 'DiscoGapicConfigPipeline' == pipeline_name)):

--- a/artman/config/converter.py
+++ b/artman/config/converter.py
@@ -32,14 +32,8 @@ def convert_to_legacy_config_dict(artifact_config, root_dir, output_dir):
     common['api_name'] = artifact_config.api_name
     common['api_version'] = artifact_config.api_version
     common['organization_name'] = artifact_config.organization_name
-    if artifact_config.service_yaml:
-        common['service_yaml'] = [artifact_config.service_yaml]
-    else:
-        common['service_yaml'] = []
-    if artifact_config.gapic_yaml:
-        common['gapic_api_yaml'] = [artifact_config.gapic_yaml]
-    else:
-        common['gapic_api_yaml'] = []
+    common['service_yaml'] = artifact_config.service_yaml
+    common['gapic_yaml'] = artifact_config.gapic_yaml
     common['src_proto_path'], excluded_proto_path = _calculate_proto_paths(
         _repeated_proto3_field_to_list(
             artifact_config.src_proto_paths))

--- a/artman/pipelines/core_generation.py
+++ b/artman/pipelines/core_generation.py
@@ -55,7 +55,7 @@ class _GoCoreTaskFactory(CoreTaskFactoryBase):
         ]
 
     def get_validate_kwargs(self):
-        return ['gapic_api_yaml', 'gapic_code_dir'] + code_gen.COMMON_REQUIRED
+        return ['gapic_yaml', 'gapic_code_dir'] + code_gen.COMMON_REQUIRED
 
 
 class _CSharpCoreTaskFactory(CoreTaskFactoryBase):

--- a/artman/pipelines/gapic_generation.py
+++ b/artman/pipelines/gapic_generation.py
@@ -23,9 +23,9 @@ from artman.utils import task_utils
 
 
 # kwargs required by GAPIC code gen
-_GAPIC_REQUIRED = ['service_yaml', 'gapic_api_yaml', 'language', 'publish']
+_GAPIC_REQUIRED = ['service_yaml', 'gapic_yaml', 'language', 'publish']
 
-_DISCOGAPIC_REQUIRED = ['gapic_api_yaml', 'language', 'publish']
+_DISCOGAPIC_REQUIRED = ['gapic_yaml', 'language', 'publish']
 
 
 class GapicConfigPipeline(code_gen.CodeGenerationPipelineBase):
@@ -120,7 +120,7 @@ class CSharpPackagingTaskFactory(code_gen.TaskFactoryBase):
         ]
 
     def get_validate_kwargs(self):
-        return ['gapic_code_dir', 'grpc_code_dir', 'proto_code_dir', 'gapic_api_yaml']
+        return ['gapic_code_dir', 'grpc_code_dir', 'proto_code_dir', 'gapic_yaml']
 
     def get_invalid_kwargs(self):
         return []

--- a/artman/pipelines/grpc_generation.py
+++ b/artman/pipelines/grpc_generation.py
@@ -108,7 +108,7 @@ class _GoGrpcTaskFactory(GrpcTaskFactoryBase):
         ]
 
     def get_validate_kwargs(self):
-        return ['gapic_api_yaml', 'gapic_code_dir'] + code_gen.COMMON_REQUIRED
+        return ['gapic_yaml', 'gapic_code_dir'] + code_gen.COMMON_REQUIRED
 
 
 class _CSharpGrpcTaskFactory(GrpcTaskFactoryBase):

--- a/artman/tasks/package_metadata_tasks.py
+++ b/artman/tasks/package_metadata_tasks.py
@@ -30,7 +30,7 @@ class PackageMetadataConfigGenTask(task_base.TaskBase):
 
     def execute(self, api_name, api_version, organization_name, output_dir,
                 proto_deps, language, root_dir, src_proto_path,
-                gapic_api_yaml, artifact_type, release_level=None,
+                artifact_type, release_level=None,
                 proto_test_deps=None):
         api_full_name = task_utils.api_full_name(
             api_name, api_version, organization_name)
@@ -38,7 +38,7 @@ class PackageMetadataConfigGenTask(task_base.TaskBase):
         config = self._create_config(
             api_name, api_version, organization_name, output_dir, proto_deps,
             proto_test_deps, language, root_dir, src_proto_path,
-            gapic_api_yaml, artifact_type, release_level)
+            artifact_type, release_level)
 
         package_metadata_config = os.path.join(
             output_dir, language + '_' + api_full_name + '_package2.yaml')
@@ -48,7 +48,7 @@ class PackageMetadataConfigGenTask(task_base.TaskBase):
 
     def _create_config(self, api_name, api_version, organization_name, output_dir,
                        proto_deps, proto_test_deps, language, root_dir, src_proto_path,
-                       gapic_api_yaml, artifact_type, release_level):
+                       artifact_type, release_level):
         googleapis_dir = root_dir
         googleapis_path = os.path.commonprefix(
             [os.path.relpath(p, googleapis_dir) for p in src_proto_path])
@@ -88,8 +88,7 @@ class ProtoPackageMetadataGenTaskBase(task_base.TaskBase):
         pkg_dir = os.path.join(
             output_dir, language, proto_prefix + api_full_name)
 
-        service_args = ['--service_yaml=' + os.path.abspath(yaml)
-                        for yaml in service_yaml]
+        service_args = ['--service_yaml=' + os.path.abspath(service_yaml)]
         args = [
             '--descriptor_set=' + os.path.abspath(descriptor_set),
             '--input=' + os.path.abspath(input_dir),

--- a/artman/tasks/protoc_tasks.py
+++ b/artman/tasks/protoc_tasks.py
@@ -60,17 +60,16 @@ class ProtocCodeGenTaskBase(task_base.TaskBase):
     def _execute_proto_codegen(
             self, language, src_proto_path, import_proto_path,
             pkg_dir, api_name, api_version, organization_name,
-            toolkit_path, gapic_api_yaml, gen_proto=False, gen_grpc=False,
+            toolkit_path, gapic_yaml, gen_proto=False, gen_grpc=False,
             final_src_proto_path=None, final_import_proto_path=None,
             excluded_proto_path=[]):
-        gapic_api_yaml = gapic_api_yaml[0] if gapic_api_yaml else None
         src_proto_path = final_src_proto_path or src_proto_path
         import_proto_path = final_import_proto_path or import_proto_path
         proto_params = protoc_utils.PROTO_PARAMS_MAP[language]
 
         if gen_proto:
             protoc_proto_params = protoc_utils.protoc_proto_params(
-                proto_params, pkg_dir, gapic_api_yaml, with_grpc=True)
+                proto_params, pkg_dir, gapic_yaml, with_grpc=True)
         else:
             protoc_proto_params = []
 
@@ -112,14 +111,14 @@ class ProtoCodeGenTask(ProtocCodeGenTaskBase):
     """Generates protos"""
     def execute(self, language, src_proto_path, import_proto_path,
                 output_dir, api_name, api_version, organization_name,
-                toolkit_path, gapic_api_yaml, final_src_proto_path=None,
+                toolkit_path, gapic_yaml, final_src_proto_path=None,
                 final_import_proto_path=None, excluded_proto_path=[]):
         pkg_dir = protoc_utils.prepare_proto_pkg_dir(
             output_dir, api_name, api_version, organization_name, language)
         return self._execute_proto_codegen(
             language, src_proto_path, import_proto_path, pkg_dir,
             api_name, api_version, organization_name, toolkit_path,
-            gapic_api_yaml, gen_proto=True,
+            gapic_yaml, gen_proto=True,
             final_src_proto_path=final_src_proto_path,
             final_import_proto_path=final_import_proto_path,
             excluded_proto_path=excluded_proto_path)
@@ -131,14 +130,14 @@ class GrpcCodeGenTask(ProtocCodeGenTaskBase):
     """Generates the gRPC client library"""
     def execute(self, language, src_proto_path, import_proto_path,
                 toolkit_path, output_dir, api_name, api_version,
-                organization_name, gapic_api_yaml, final_src_proto_path=None,
+                organization_name, gapic_yaml, final_src_proto_path=None,
                 final_import_proto_path=None, excluded_proto_path=[]):
         pkg_dir = protoc_utils.prepare_grpc_pkg_dir(
             output_dir, api_name, api_version, organization_name, language)
         return self._execute_proto_codegen(
             language, src_proto_path, import_proto_path, pkg_dir,
             api_name, api_version,  organization_name, toolkit_path,
-            gapic_api_yaml, gen_grpc=True,
+            gapic_yaml, gen_grpc=True,
             final_src_proto_path=final_src_proto_path,
             final_import_proto_path=final_import_proto_path,
             excluded_proto_path=excluded_proto_path)
@@ -150,14 +149,14 @@ class ProtoAndGrpcCodeGenTask(ProtocCodeGenTaskBase):
     """Generates protos and the gRPC client library"""
     def execute(self, language, src_proto_path, import_proto_path,
                 toolkit_path, output_dir, api_name, api_version,
-                organization_name, gapic_api_yaml, final_src_proto_path=None,
+                organization_name, gapic_yaml, final_src_proto_path=None,
                 final_import_proto_path=None, excluded_proto_path=[]):
         pkg_dir = protoc_utils.prepare_grpc_pkg_dir(
             output_dir, api_name, api_version, organization_name, language)
         return self._execute_proto_codegen(
             language, src_proto_path, import_proto_path, pkg_dir,
             api_name, api_version, organization_name, toolkit_path,
-            gapic_api_yaml, gen_proto=True, gen_grpc=True,
+            gapic_yaml, gen_proto=True, gen_grpc=True,
             final_src_proto_path=final_src_proto_path,
             final_import_proto_path=final_import_proto_path,
             excluded_proto_path=excluded_proto_path)

--- a/artman/utils/protoc_utils.py
+++ b/artman/utils/protoc_utils.py
@@ -228,14 +228,14 @@ def protoc_desc_params(output_dir, desc_out_file):
              '-o', os.path.join(output_dir, desc_out_file)])
 
 
-def protoc_proto_params(proto_params, pkg_dir, gapic_api_yaml, with_grpc):
+def protoc_proto_params(proto_params, pkg_dir, gapic_yaml, with_grpc):
     params = []
     lang_param = proto_params.lang_out_param(pkg_dir, with_grpc)
     if lang_param:
         params += lang_param.split(' ')
     # plugin out must come after lang out
     plugin_param = proto_params.proto_plugin_path()
-    plugin_out = proto_params.plugin_out_param(pkg_dir, gapic_api_yaml)
+    plugin_out = proto_params.plugin_out_param(pkg_dir, gapic_yaml)
     if plugin_param and plugin_out:
         params.append('--plugin=protoc-gen-plgn={}'.format(plugin_param))
         params.append(plugin_out)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -79,7 +79,7 @@ class NormalizeFlagTests(unittest.TestCase):
         name, args = main.normalize_flags(self.flags, self.user_config)
         assert name == 'GapicClientPipeline'
         assert args['desc_proto_path'][0].endswith('google/iam/v1')
-        assert args['gapic_api_yaml'][0].endswith('test_gapic.yaml')
+        assert args['gapic_yaml'].endswith('test_gapic.yaml')
         assert args['toolkit']
         assert 'github' not in args
         assert args['language'] == 'python'

--- a/test/config/test_converter.py
+++ b/test/config/test_converter.py
@@ -47,8 +47,9 @@ class ConverterTest(unittest.TestCase):
             expected_legacy_config_dict = yaml.load(yaml_file)
             self.assertDictEqual(
                 expected_legacy_config_dict, actual_legacy_config_dict,
-                'Actual yaml is \n%s' % yaml.dump(
-                    actual_legacy_config_dict, default_flow_style=False))
+                'Actual yaml is:\n{}\nExpected yaml is:\n{}\n'.format(
+                    yaml.dump(actual_legacy_config_dict, default_flow_style=False),
+                    yaml.dump(expected_legacy_config_dict, default_flow_style=False)))
 
 
 if __name__ == '__main__':

--- a/test/config/testdata/expected_pubsub_java_legacy_config.yaml
+++ b/test/config/testdata/expected_pubsub_java_legacy_config.yaml
@@ -3,8 +3,7 @@ common:
   api_version: v1
   desc_proto_path:
   - /tmp/input/google/iam/v1
-  gapic_api_yaml:
-  - /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
+  gapic_yaml: /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
   import_proto_path:
   - /tmp/input
   organization_name: google-cloud
@@ -13,8 +12,7 @@ common:
   proto_deps:
   - google-common-protos
   - google-iam-v1
-  service_yaml:
-  - /tmp/input/google/pubsub/pubsub.yaml
+  service_yaml: /tmp/input/google/pubsub/pubsub.yaml
   src_proto_path:
   - /tmp/input/google/pubsub/v1
   excluded_proto_path:

--- a/test/config/testdata/expected_pubsub_java_proto_legacy_config.yaml
+++ b/test/config/testdata/expected_pubsub_java_proto_legacy_config.yaml
@@ -5,8 +5,7 @@ common:
   - /tmp/input/google/iam/v1
   excluded_proto_path:
   - /tmp/input/google/pubsub/v1/excluded
-  gapic_api_yaml:
-  - /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
+  gapic_yaml: /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
   import_proto_path:
   - /tmp/input
   organization_name: google-cloud
@@ -17,8 +16,7 @@ common:
   - google-iam-v1
   proto_test_deps:
   - google-iam-v1
-  service_yaml:
-  - /tmp/input/google/pubsub/pubsub.yaml
+  service_yaml: /tmp/input/google/pubsub/pubsub.yaml
   src_proto_path:
   - /tmp/input/google/pubsub/v1
 java:

--- a/test/config/testdata/expected_pubsub_python_legacy_config.yaml
+++ b/test/config/testdata/expected_pubsub_python_legacy_config.yaml
@@ -3,8 +3,7 @@ common:
   api_version: v1
   desc_proto_path:
   - /tmp/input/google/iam/v1
-  gapic_api_yaml:
-  - /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
+  gapic_yaml: /tmp/input/google/pubsub/v1/pubsub_gapic.yaml
   import_proto_path:
   - /tmp/input
   organization_name: google-cloud
@@ -13,8 +12,7 @@ common:
   proto_deps:
   - google-common-protos
   - google-iam-v1
-  service_yaml:
-  - /tmp/input/google/pubsub/pubsub.yaml
+  service_yaml: /tmp/input/google/pubsub/pubsub.yaml
   src_proto_path:
   - /tmp/input/google/pubsub/v1
   excluded_proto_path:

--- a/test/tasks/test_gapic.py
+++ b/test/tasks/test_gapic.py
@@ -44,7 +44,7 @@ class GapicConfigGenTaskTests(unittest.TestCase):
             descriptor_set='/path/to/descriptor_set',
             organization_name='google-cloud',
             output_dir='/path/to/output',
-            service_yaml=['/path/to/service.yaml'],
+            service_yaml='/path/to/service.yaml',
             toolkit_path='/path/to/toolkit',
         )
         assert result == '/'.join((
@@ -107,7 +107,7 @@ class GapicConfigMoveTaskTests(unittest.TestCase):
     @mock.patch.object(gapic_tasks.GapicConfigMoveTask, 'exec_command')
     def test_execute(self, exec_command):
         task = gapic_tasks.GapicConfigMoveTask()
-        task.execute('/path/src', ['/path/dest'])
+        task.execute('/path/src', '/path/dest')
         assert exec_command.call_count == 2
         expected_cmds = [
             'mkdir -p /path',
@@ -119,14 +119,7 @@ class GapicConfigMoveTaskTests(unittest.TestCase):
     def test_execute_no_dest(self, exec_command):
         task = gapic_tasks.GapicConfigMoveTask()
         with pytest.raises(ValueError):
-            task.execute('/path/src', [])
-        assert exec_command.call_count == 0
-
-    @mock.patch.object(gapic_tasks.GapicConfigMoveTask, 'exec_command')
-    def test_execute_multi_dest(self, exec_command):
-        task = gapic_tasks.GapicConfigMoveTask()
-        with pytest.raises(ValueError):
-            task.execute('/path/src', ['/path/one', '/path/two'])
+            task.execute('/path/src', None)
         assert exec_command.call_count == 0
 
     @mock.patch.object(gapic_tasks.GapicConfigMoveTask, 'exec_command')
@@ -134,7 +127,7 @@ class GapicConfigMoveTaskTests(unittest.TestCase):
     def test_execute_dest_exists(self, exists, exec_command):
         exists.return_value = True
         task = gapic_tasks.GapicConfigMoveTask()
-        task.execute('/path/src', ['/path/exists'])
+        task.execute('/path/src', '/path/exists')
         assert exec_command.call_count == 3
         expected_cmds = [
             'mv /path/exists /path/exists.old',
@@ -157,12 +150,12 @@ class GapicCodeGenTaskTests(unittest.TestCase):
             api_name='pubsub',
             api_version='v1',
             descriptor_set='/path/to/desc',
-            gapic_api_yaml=['/path/to/pubsub.yaml'],
+            gapic_yaml='/path/to/pubsub.yaml',
             gapic_code_dir='/path/to/output',
             language='python',
             organization_name='google-cloud',
             package_metadata_yaml='/path/to/pmy.yaml',
-            service_yaml=['/path/to/service.yaml'],
+            service_yaml='/path/to/service.yaml',
             toolkit_path='/path/to/toolkit'
         )
         expected_cmds = [
@@ -190,7 +183,7 @@ class DiscoGapicCodeGenTaskTests(unittest.TestCase):
         task.execute(
             api_name='compute',
             api_version='v1',
-            gapic_api_yaml=['/path/to/compute.yaml'],
+            gapic_yaml='/path/to/compute.yaml',
             gapic_code_dir='/path/to/output',
             language='java',
             organization_name='google-cloud',

--- a/test/test_package_metadata_task.py
+++ b/test/test_package_metadata_task.py
@@ -35,7 +35,6 @@ class PackageMetadataConfigTest(unittest.TestCase):
         task.execute(
             api_name='fake',
             api_version='v1',
-            gapic_api_yaml=[],
             language='python',
             root_dir='%s/googleapis' % repo_root,
             organization_name='google-cloud',


### PR DESCRIPTION
- Before: `gapic_yaml` & `service_yaml` were each added to a single-item list (as `gapic_api_yaml` & `service_yaml`)
- After: the original `gapic_yaml` & `service_yaml` values are plumbed through everywhere

This conversion to a list was done because we used to merge with the legacy language configs that have since been deprecated. 

Net deletion!
