### PR TITLE
Add --generator_args to pass a string of args to gapic-generator

### DIFF
--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -167,7 +167,7 @@ def parse_args(*args):
         help=('[Optional] Specify docker image used by artman when running in '
               'a Docker instance. Default to `%s`' % ARTMAN_DOCKER_IMAGE))
     parser.add_argument(
-        '--generator_args',
+        '--generator-args',
         type=str,
         default=None,
         help='Additional arguments to pass to gapic-generator')

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -165,7 +165,13 @@ def parse_args(*args):
         '--image',
         default=ARTMAN_DOCKER_IMAGE,
         help=('[Optional] Specify docker image used by artman when running in '
-              'a Docker instance. Default to `%s`' % ARTMAN_DOCKER_IMAGE)),
+              'a Docker instance. Default to `%s`' % ARTMAN_DOCKER_IMAGE))
+    parser.add_argument(
+        '--generator_args',
+        type=str,
+        default=None,
+        help='Additional arguments to pass to gapic-generator')
+
 
     # Add sub-commands.
     subparsers = parser.add_subparsers(
@@ -222,6 +228,7 @@ def normalize_flags(flags, user_config):
     # toolkit on his or her machine.
     pipeline_args['root_dir'] = root_dir
     pipeline_args['toolkit_path'] = user_config.local.toolkit
+    pipeline_args['generator_args'] = flags.generator_args
 
     artman_config_path = flags.config
     if not os.path.isfile(artman_config_path):

--- a/artman/tasks/gapic_tasks.py
+++ b/artman/tasks/gapic_tasks.py
@@ -36,7 +36,7 @@ class GapicConfigGenTask(task_base.TaskBase):
                                        api_full_name + '_gapic.yaml')
         args = [
             '--descriptor_set=' + os.path.abspath(descriptor_set),
-            '--output=' + os.path.abspath(config_gen_path)
+            '--output=' + os.path.abspath(config_gen_path),
         ]
         if service_yaml:
             args = args + ['--service_yaml=' + os.path.abspath(service_yaml)]
@@ -103,7 +103,7 @@ class GapicCodeGenTask(task_base.TaskBase):
     def execute(self, language, toolkit_path, descriptor_set, service_yaml,
                 gapic_yaml, package_metadata_yaml,
                 gapic_code_dir, api_name, api_version, organization_name,
-                aspect):
+                aspect, generator_args):
         existing = glob.glob('%s/*' % gapic_code_dir)
         if existing:
             self.exec_command(['rm', '-r'] + existing)
@@ -117,6 +117,9 @@ class GapicCodeGenTask(task_base.TaskBase):
         if service_yaml:
             args = args + ['--service_yaml=' + os.path.abspath(service_yaml)]
         args = args + gapic_args
+
+        if generator_args:
+          args = args + generator_args.split(' ')
 
         gapic_artifact = ''
         if aspect == 'ALL':

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -57,6 +57,7 @@ class NormalizeFlagTests(unittest.TestCase):
             github_username='test', github_token='testtoken',
             artifact_name='python_gapic',
             aspect=None,
+            generator_args=["--dev_samples --other"],
             output_dir='./artman-genfiles',
             dry_run=False,
             local_repo_dir=None,
@@ -73,3 +74,4 @@ class NormalizeFlagTests(unittest.TestCase):
         assert args['gapic_yaml'].endswith('test_gapic.yaml')
         assert args['toolkit_path']
         assert args['language'] == 'python'
+        assert args['generator_args'] == ['--dev_samples --other']

--- a/test/tasks/test_gapic.py
+++ b/test/tasks/test_gapic.py
@@ -158,6 +158,7 @@ class GapicCodeGenTaskTests(unittest.TestCase):
             service_yaml='/path/to/service.yaml',
             toolkit_path='/path/to/toolkit',
             aspect='ALL',
+            generator_args='--extra_args'
         )
         expected_cmds = [
             ' '.join(['java -cp',
@@ -167,6 +168,7 @@ class GapicCodeGenTaskTests(unittest.TestCase):
                       '--output=/path/to/output --language=python',
                       '--service_yaml=/path/to/service.yaml',
                       '--gapic_yaml=/path/to/pubsub.yaml',
+                      '--extra_args'
                       ])
         ]
         assert_calls_equal(exec_command.mock_calls, expected_cmds)


### PR DESCRIPTION
I have not been able to figure out how to make the parser accept everything after a "-- " as arguments. I can do it on a standalone example, but I think the generate subcommand does not interact well with it.

This PR includes tests.

This addresses #508. The immediate motivation is to enable easier sample gen for languages in which samples have not yet been officially launched.
