### PR TITLE
bump gapic-generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH e26f9c7cdefd2118823d4af5902471507eb7b3e4
-ENV GAPIC_GENERATOR_HASH 45610dd51d26d3eb51c883a331f93b746eb38379
+ENV GAPIC_GENERATOR_HASH 2958caa2e9243e7bbd94a270845404a691fffee3
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.16.3


### PR DESCRIPTION
Bump gapic-generator hash to include:
* change Go gapics use gax-go/v2
* Samplegen: initialize a resource name with parameters
* [golang] Mark "beta" APIs as beta