### PR TITLE
Update gapic-generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH ac33855ebab4995167d88e8d3975f181098fc6c6
-ENV GAPIC_GENERATOR_HASH 020d212b027ea7b1c69897a2c3255e1e39190a72
+ENV GAPIC_GENERATOR_HASH 47ae8d82de2d46e18cbfb990a4d5dbd02c314d29
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.16.9


### PR DESCRIPTION
The updated hash includes [googleapis/gapic-generator#2542](https://github.com/googleapis/gapic-generator/pull/2542) which fixed a Go example_test.go import churn problem.

It also includes changes for Bazel Go build rules and disco-gapic fixes.