### PR TITLE
Update gapic-generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH fa39cea186a3caa2f386e82f7653d189ecffaa9a
-ENV GAPIC_GENERATOR_HASH 388b8a855d08c8455f04a5d9f6874f207c642c41
+ENV GAPIC_GENERATOR_HASH 5c5b7b9c24653600ecf4b238df266f9077410dad
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.18.0


### PR DESCRIPTION
Include these new features in gapic-generator:
- SampleGen: put PHP, Python and Ruby samples in the correct directory
- Remove all references of DEADLINE_EXCEEDED
- PHP: Update gax version to 1.0.2 (#2750)