### PR TITLE
Release 0.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH ab437f2bb2100360f8d119530b0a020228baa4cc
 ENV GAPIC_GENERATOR_HASH 046b0c6efb1d232f12f857396857ec9c31d6f103
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.20.0
+ENV ARTMAN_VERSION 0.21.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
- SampleGen: use the correct default calling form for Java LRO methods
- SampleGen: generate the correct Gemfile for Ruby samples
- SampleGen: Accept enum values as CLI flags
- SampleGen: use application plugin in build.gradle of the sample package
- Java: Remove duplicate imports in Java
- Python: avoid coverage failure when no `_shared_modules` are present