### PR TITLE
fix: grafeas can also be a top-level protocol folder

### DIFF
--- a/artman/utils/protoc_utils.py
+++ b/artman/utils/protoc_utils.py
@@ -269,7 +269,7 @@ def protoc_grpc_params(proto_params, pkg_dir, toolkit_path):
 
 
 def find_google_dir_index(src_proto_path):
-    matches = list(re.finditer('(?:\\A|[/\\\\])(google)(?=\\Z|[/\\\\])',
+    matches = list(re.finditer('(?:\\A|[/\\\\])(google|grafeas)(?=\\Z|[/\\\\])',
                                src_proto_path))
     if len(matches) == 0:
         raise ValueError('src_proto_path did not contain "google" '


### PR DESCRIPTION
we are [failing to run synthtool each night](https://github.com/googleapis/nodejs-grafeas/issues/5) because `google` is the only supported top level folder for protos.