### PR TITLE
Update gapic-generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
-ENV GAPIC_GENERATOR_HASH 450dc0d65117a12823b33a3e3ea97240f90942f1
+ENV GAPIC_GENERATOR_HASH f4a823d9f5df9da8f064058725b3c0c43bda5e3b
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.30.1


### PR DESCRIPTION
Adding the following features from gapic-generator:
- Java: Remove unsupported retry samples
- Java: Add `@generated` to generated package-info files
- Node.js: drop dependency on through2