### PR TITLE
Really use temporary directory when generating discogapic configs

### DIFF
--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -286,8 +286,7 @@ def normalize_flags(flags, user_config):
 
     # Parse out the full configuration.
     config_args = config_util.load_config_spec(legacy_config_dict, language)
-    pipeline_args.update(config_args)
-
+    pipeline_args = dict(config_args.items() + pipeline_args.items())
     # Print out the final arguments to stdout, to help the user with
     # possible debugging.
     pipeline_args_repr = yaml.dump(

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -286,7 +286,8 @@ def normalize_flags(flags, user_config):
 
     # Parse out the full configuration.
     config_args = config_util.load_config_spec(legacy_config_dict, language)
-    pipeline_args = dict(config_args.items() + pipeline_args.items())
+    config_args.update(pipeline_args)
+    pipeline_args = pipeline_args
     # Print out the final arguments to stdout, to help the user with
     # possible debugging.
     pipeline_args_repr = yaml.dump(

--- a/artman/cli/main.py
+++ b/artman/cli/main.py
@@ -287,7 +287,7 @@ def normalize_flags(flags, user_config):
     # Parse out the full configuration.
     config_args = config_util.load_config_spec(legacy_config_dict, language)
     config_args.update(pipeline_args)
-    pipeline_args = pipeline_args
+    pipeline_args = config_args
     # Print out the final arguments to stdout, to help the user with
     # possible debugging.
     pipeline_args_repr = yaml.dump(


### PR DESCRIPTION
The temporary directory was overridden during `pipeline_args.update(config_args)`.