### PR TITLE
release v0.36.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
 ENV GAPIC_GENERATOR_HASH 894447d439c074296297b9a45d90201e30553b79
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.36.0
+ENV ARTMAN_VERSION 0.36.1
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Releasing version v0.36.1.

Includes a fix for Node.js: https://github.com/googleapis/gapic-generator/pull/2960