### PR TITLE
Update gapic-generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
-ENV GAPIC_GENERATOR_HASH 99027b6791c1125b7f0dae331e36926c468e07e6
+ENV GAPIC_GENERATOR_HASH 82e4b43277d3783fd261cb319f0606ac8c9e1ddb
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.36.2


### PR DESCRIPTION
to include the following features from gapic-generator:
* Remove rogue entrySet call when iterating over maps in C# samples
* C# samples: fix incorrect bracing style and and a newline at EOF
* SampleGen: import OperationFuture and XxxMetadata for LRO samples