### PR TITLE
Release 0.38.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
 ENV GAPIC_GENERATOR_HASH 1bfe1a98586744038019f1d0bd90817a170f22d2
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.37.1
+ENV ARTMAN_VERSION 0.38.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
To include the following features from gapic-generator:

- SampleGen: generates sample manifest file for Java samples (#2992)
- Python: Update URL for 'requests' Sphinx inventory. (#2990)