### PR TITLE
Release 0.39.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
 ENV GAPIC_GENERATOR_HASH 953dd8ebaed78b817e461f2f6b474fa314068e3a
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.38.0
+ENV ARTMAN_VERSION 0.39.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
To include the following changes from gapic generator:
- Fix iam dependency resolution for java_gapic_assembly_gradle_pkg
- Parse resource name annotations from imported protos too

and the following changes in artman:
- Bug fix when resource names plugin is called without gapic.yaml