### PR TITLE
Release 0.40.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
 ENV GAPIC_GENERATOR_HASH 9d88954f1107c95cf299ed9e35a455396bd4dba6
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.40.1
+ENV ARTMAN_VERSION 0.40.2
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
To include the following feature from gapic-generator:
- SampleGen: update Node.js const name for library package (#2969)