### PR TITLE
release v0.41.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
 ENV GAPIC_GENERATOR_HASH 42cc5dd62dc38f71f7e203f07bb16117e6310b5a
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.40.3
+ENV ARTMAN_VERSION 0.41.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
gapic-generator: No changes

artman:
* add grpc_service_config attribute to artman config (https://github.com/googleapis/artman/pull/755)