### PR TITLE
DO NOT MERGE: use protoc master for PHP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,6 @@ jobs:
             docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
             docker tag artman "googleapis/artman:AUTO_BUILD_$CIRCLE_BUILD_NUM"
             docker push "googleapis/artman:AUTO_BUILD_$CIRCLE_BUILD_NUM"
-            docker tag artman "googleapis/artman:head"
-            docker push "googleapis/artman:head"
 
   release:
     working_directory: /usr/src/artman
@@ -225,15 +223,4 @@ workflows:
             - unit-python3.6
             - docs
             - golden_and_smoke_tests
-          filters:
-            branches:
-              only: master
-            tags: &releases
-              only: '/^v[\d.]+$/'
-      - release:
-          requires:
-            - build_and_release_docker_image
-          filters:
-            branches:
-              ignore: /.*/
-            tags: *releases
+          filters: *all_commits

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -14,13 +14,13 @@ protobuf_versions[nodejs]=3.8.0
 protobuf_versions[go]=3.8.0
 protobuf_versions[python]=3.8.0
 protobuf_versions[ruby]=3.8.0
-protobuf_versions[php]=3.9.0-rc1
+protobuf_versions[php]=master-20191115
 protobuf_versions[csharp]=3.8.0
 # Protobuf Java dependency must match grpc-java's protobuf dep.
 protobuf_versions[java]=3.7.1
 
 # RC1 url has no logic: compare rc1 in the folder name with rc-1 in the filename
-override_download_location[3.9.0-rc1]=https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0-rc1/protoc-3.9.0-rc-1-linux-x86_64.zip
+override_download_location[master-20191115]=https://storage.googleapis.com/artman/protoc-20191115
 
 # Install each unique protobuf version.
 for i in "${protobuf_versions[@]}"

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -20,7 +20,7 @@ protobuf_versions[csharp]=3.8.0
 protobuf_versions[java]=3.7.1
 
 # RC1 url has no logic: compare rc1 in the folder name with rc-1 in the filename
-override_download_location[master-20191115]=https://storage.googleapis.com/artman/protoc-20191115
+override_download_location[master-20191115]=https://storage.googleapis.com/artman/protoc-20191115.zip
 
 # Install each unique protobuf version.
 for i in "${protobuf_versions[@]}"
@@ -29,11 +29,13 @@ do
   if [ "${override_download_location[$i]}" != "" ]; then
     location=${override_download_location[$i]}
   fi
+  echo "$i $location"
   mkdir -p /usr/src/protoc-${i}/ \
       && curl --location $location > /usr/src/protoc-${i}/protoc.zip \
       && cd /usr/src/protoc-${i}/ \
       && unzip protoc.zip \
       && rm protoc.zip \
+      && chmod +x /usr/src/protoc-${i}/bin/protoc \
       && ln -s /usr/src/protoc-${i}/bin/protoc /usr/local/bin/protoc-${i}
 done
 


### PR DESCRIPTION
DO NOT MERGE

Using `protoc` from master, stored on GCS, for PHP.