### PR TITLE
update googleapis hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 # Release parameters
-ENV GOOGLEAPIS_HASH 47bd0c2ba33c28dd624a65dad382e02bb61d1618
+ENV GOOGLEAPIS_HASH e47fdd266542386e5e7346697f90476e96dc7ee8
 ENV GAPIC_GENERATOR_HASH bcedba65bf930d3e35530fe5360f1c6f24d27abc
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ stringcase >= 1.2.0, < 2.0.0
 taskflow==3.7.1
 networkx==1.11
 pypandoc >= 1.4, < 2.0
+ply >= 3.8


### PR DESCRIPTION
It turns out we might need to update internal googleapis copy (inside the Docker image) since we updated `google/cloud/common_resources.proto`. I'm really unsure how exactly it is used, but we got a bug report that this file is missing, and this is the first place I thought of. Let's try updating this hash.