### PR TITLE
release v0.42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH e47fdd266542386e5e7346697f90476e96dc7ee8
 ENV GAPIC_GENERATOR_HASH bcedba65bf930d3e35530fe5360f1c6f24d27abc
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.42.1
+ENV ARTMAN_VERSION 0.42.2
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
The `googleapis` repository inside the Docker image has been updated in this release.
Also, `protoc` v3.10 is now used for Java (#770).