### PR TITLE
release v0.43.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOOGLEAPIS_HASH e47fdd266542386e5e7346697f90476e96dc7ee8
 ENV GAPIC_GENERATOR_HASH a481c9d2a6063594ddbd4c3cc1fb2320b89f9c56
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
-ENV ARTMAN_VERSION 0.42.3
+ENV ARTMAN_VERSION 0.43.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
New features:

- node.js: feat: add explicit require for mocha https://github.com/googleapis/gapic-generator/pull/3063
- python: un-deprecate resource name functions https://github.com/googleapis/gapic-generator/pull/3062
- python: deprecation warning for Python 2.7 https://github.com/googleapis/gapic-generator/pull/3059
- bazel-related fixes