### PR TITLE
Update resource name plugin version and gapic generator hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH e47fdd266542386e5e7346697f90476e96dc7ee8
-ENV GAPIC_GENERATOR_HASH d5b254370a45b8e5f283c5626345665b80b3360f
+ENV GAPIC_GENERATOR_HASH bcf77f997685140eb5fc2e40fc4ebf8a5c56d28f
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 0.44.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ oslo.utils >= 3.41.0, < 4.0.0
 pbr >= 5.4.2, < 6.0.0
 protobuf >= 3.9.0, < 4.0.0
 protobuf3-to-dict==0.1.5
-protoc-java-resource-names-plugin >= 0.0.18, < 0.1.0
+protoc-java-resource-names-plugin >= 0.0.20, < 0.1.0
 requests >= 2.22.0, < 3.0.0
 ruamel.yaml >= 0.16.0, < 0.17.0
 six >= 1.12.0, < 2.0.0


### PR DESCRIPTION
Include the following features:

gapic generator:
- Support empty method signatures (#3067)
- Stop guessing entity names for patterns of multi-pattern resources (#3044)

resource name plugin:
- Support the new multi-pattern resource name (#66)