### PR TITLE
run protoc in one invocation (and stop testing Python 2.7)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,23 +157,10 @@ jobs:
       - *checkout_artman
       - run:
           name: Install nox.
-          command: pip install --upgrade nox-automation==0.19.1
+          command: pip install --upgrade nox-automation
       - run:
           name: Build the docs.
-          command: nox -e docs
-    working_directory: /usr/src/artman/
-
-  unit-python2.7:
-    docker:
-      - image: python:2.7
-    steps:
-      - checkout
-      - run:
-          name: Install nox and codecov.
-          command: pip install --upgrade nox-automation==0.19.1 codecov
-      - run:
-          name: Run unit tests.
-          command: nox -e "unit_tests(python_version='2.7')"
+          command: nox --session docs
     working_directory: /usr/src/artman/
 
   unit-python3.5:
@@ -183,10 +170,10 @@ jobs:
       - *checkout_artman
       - run:
           name: Install nox and codecov.
-          command: pip install --upgrade nox-automation==0.19.1 codecov
+          command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='3.5')"
+          command: nox --session unit_tests-3.5
     working_directory: /usr/src/artman/
 
   unit-python3.6:
@@ -196,17 +183,30 @@ jobs:
       - checkout
       - run:
           name: Install nox and codecov.
-          command: pip install --upgrade nox-automation==0.19.1 codecov
+          command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='3.6')"
+          command: nox --session unit_tests-3.6
+    working_directory: /usr/src/artman/
+
+  unit-python3.7:
+    docker:
+      - image: python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install nox and codecov.
+          command: pip install --upgrade nox-automation codecov
+      - run:
+          name: Run unit tests.
+          command: nox --session unit_tests-3.7
     working_directory: /usr/src/artman/
 
 workflows:
   version: 2
   tests:
     jobs:
-      - unit-python2.7:
+      - unit-python3.7:
           filters: &all_commits
             tags:
               only: /.*/
@@ -220,7 +220,6 @@ workflows:
           filters: *all_commits
       - build_and_release_docker_image:
           requires:
-            - unit-python2.7
             - unit-python3.5
             - unit-python3.6
             - docs

--- a/artman/tasks/protoc_tasks.py
+++ b/artman/tasks/protoc_tasks.py
@@ -115,11 +115,16 @@ class ProtocCodeGenTaskBase(task_base.TaskBase):
         # The order of the input files affects comments and internal variables.
         # While this doesn't affect the correctness of the result, we sort
         # proto files for reproducibility.
-        #
-        # Other languages don't mind us doing this, so we just do it for
-        # everyone.
-        for (dirname, protos) in protoc_utils.group_by_go_package(
-                protoc_utils.find_protos(src_proto_path, excluded_proto_path)).items():
+
+        # For other languages, we'll pass all proto files into the same protoc
+        # invocation (PHP especially needs that).
+        all_protos = protoc_utils.find_protos(src_proto_path, excluded_proto_path)
+        if language == "go":
+            protos_map = protoc_utils.group_by_go_package(all_protos)
+        else:
+            protos_map = { "": all_protos }
+
+        for (dirname, protos) in protos_map.items():
             # It is possible to get duplicate protos. De-dupe them.
             protos = sorted(set(protos))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,13 +18,9 @@ import nox
 import os
 
 
-@nox.session
-@nox.parametrize('python_version', ['2.7', '3.4', '3.5', '3.6'])
-def unit_tests(session, python_version):
+@nox.session(python=['3.4', '3.5', '3.6', '3.7'])
+def unit_tests(session):
     """Run the unit test suite."""
-
-    # Run unit tests against all supported versions of Python.
-    session.interpreter = 'python{}'.format(python_version)
 
     # Install all test dependencies, then install this package in-place.
     session.install('mock', 'pytest', 'pytest-cov', 'pyfakefs',
@@ -35,19 +31,17 @@ def unit_tests(session, python_version):
     session.run('py.test', '-rxs', '--cov', '--cov-append', '--cov-report=')
 
 
-@nox.session
+@nox.session(python='3.6')
 def lint(session):
     """Run the linter."""
-    session.interpreter = 'python3.6'
     session.install('flake8')
     session.run('flake8', '--max-complexity=8', 'artman',
                 '--exclude=test/output', 'test')
 
 
-@nox.session
+@nox.session(python='3.6')
 def coverage(session):
     """Provide a coverage report."""
-    session.interpreter = 'python3.6'
     session.install('coverage')
     try:
         # session.run('coverage', 'report')
@@ -56,12 +50,9 @@ def coverage(session):
         session.run('coverage', 'erase')
 
 
-@nox.session
+@nox.session(python='3.6')
 def docs(session):
     """Build the docs."""
-
-    # Set the virtualenv dirname.
-    session.virtualenv_dirname = 'docs'
 
     # Install Sphinx and also all of the google-cloud-* packages.
     session.chdir(os.path.realpath(os.path.dirname(__file__)))

--- a/test/tasks/data/googleapis/google/go_package_example/v1/first.proto
+++ b/test/tasks/data/googleapis/google/go_package_example/v1/first.proto
@@ -1,0 +1,1 @@
+option go_package = "google.golang.org/genproto/googleapis/package1/v1;package1";

--- a/test/tasks/data/googleapis/google/go_package_example/v1/second.proto
+++ b/test/tasks/data/googleapis/google/go_package_example/v1/second.proto
@@ -1,0 +1,1 @@
+option go_package = "google.golang.org/genproto/googleapis/package2/v1;package2";

--- a/test/tasks/test_protoc.py
+++ b/test/tasks/test_protoc.py
@@ -77,6 +77,38 @@ class PhpGrpcRenameTaskTests(unittest.TestCase):
         finally:
             os.remove(moved_file)
 
+class ProtoCodeGenTaskTests(unittest.TestCase):
+    # For go, it's important to make one protoc invocation per go package.
+    # For php, it's important to have just one protoc invocation.
+    # Other languages don't care at all.
+
+    @mock.patch.object(protoc_tasks.ProtoCodeGenTask, 'exec_command')
+    @mock.patch('artman.utils.protoc_utils.protoc_header_params')
+    def test_execute_go(self, exec_command, protoc_header_params):
+        protoc_header_params.return_value = ['protoc_header_params']
+        src_proto_path = ['test/tasks/data/googleapis/google/go_package_example/v1']
+        task = protoc_tasks.ProtoCodeGenTask()
+
+        # oh, that's a lot of parameters, none of them are needed now!
+        task.execute('go', src_proto_path, [], 'output_dir', 'api_name', 'v1', 
+                'org_name', 'toolkit_path', 'gapic_yaml', 'root_dir')
+
+        assert exec_command.call_count == 2
+
+
+    @mock.patch.object(protoc_tasks.ProtoCodeGenTask, 'exec_command')
+    @mock.patch('artman.utils.protoc_utils.protoc_header_params')
+    def test_execute_php(self, exec_command, protoc_header_params):
+        protoc_header_params.return_value = ['protoc_header_params']
+        src_proto_path = ['test/tasks/data/googleapis/google/go_package_example/v1']
+        task = protoc_tasks.ProtoCodeGenTask()
+
+        # oh, that's a lot of parameters, none of them are needed now!
+        task.execute('php', src_proto_path, [], 'output_dir', 'api_name', 'v1', 
+                'org_name', 'toolkit_path', 'gapic_yaml', 'root_dir')
+
+        assert exec_command.call_count == 1
+
 
 def test_find_google_dir_index():
     expected = [


### PR DESCRIPTION
In this PR:

- make sure we pass all the protos to the same `protoc` invocation for all languages except Go. For Go, keep doing what we are doing: split list of protos into several invocation based on `go_package` option.
- added tests that cover this functionality.
- when adding those tests, figured out that the code being changed does not work on Python 2.7 at all. Since it's dead and we use 3.x inside Docker anyway, let's stop testing on 2.7.
- also, made sure our tests work with the latest `nox` version.

All in the same PR - sorry for that!