### PR TITLE
Update gapic-generator hash and Java resource name plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Release parameters
 ENV GOOGLEAPIS_HASH e47fdd266542386e5e7346697f90476e96dc7ee8
-ENV GAPIC_GENERATOR_HASH ef5d22b920d73f6b996e012d7235313c4ebc4428
+ENV GAPIC_GENERATOR_HASH 8d53d31494bebc1e1da4ed0d1352f1f35441d439
 # Define version number below. The ARTMAN_VERSION line is parsed by
 # .circleci/config.yml and setup.py, please keep the format.
 ENV ARTMAN_VERSION 1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ oslo.utils>=3.41.0, <4.2.0
 pbr >= 5.4.2, < 6.0.0
 protobuf >= 3.9.0, < 4.0.0
 protobuf3-to-dict==0.1.5
-protoc-java-resource-names-plugin >= 0.0.24, < 0.1.0
+protoc-java-resource-names-plugin >= 0.0.25, < 0.1.0
 requests >= 2.22.0, < 3.0.0
 ruamel.yaml >= 0.16.0, < 0.17.0
 six >= 1.12.0, < 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ google-api-python-client >= 1.7.10
 msgpack-python >= 0.5.6, < 0.6.0
 networkx==1.11
 kazoo >= 2.6.1, < 3.0.0
-oslo.utils>=3.41.0, <4.0.1
+oslo.utils>=3.41.0, <4.2.0
 pbr >= 5.4.2, < 6.0.0
 protobuf >= 3.9.0, < 4.0.0
 protobuf3-to-dict==0.1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ flake8==3.7.9
 mccabe==0.6.1
 mock>=3.0.5, <4.0.2
 pycodestyle==2.5.0
-pyfakefs >= 3.6, < 4.0
+pyfakefs>=3.6, <4.1
 pyflakes==2.1.1
 pytest >= 5.0.1, < 6.0.0
 pytest-cov >= 2.7.1, < 3.0.0

--- a/test/golden/library_example.golden
+++ b/test/golden/library_example.golden
@@ -141,7 +141,7 @@
 /python/library_example-v1/google/cloud/example/library_v1/proto/library_pb2.py
 /python/library_example-v1/google/cloud/example/library_v1/proto/library_pb2_grpc.py
 /python/library_example-v1/google/cloud/example/library_v1/types.py
-/python/library_example-v1/nox.py
+/python/library_example-v1/noxfile.py
 /python/library_example-v1/setup.cfg
 /python/library_example-v1/setup.py
 /python/library_example-v1/tests/unit/gapic/v1/test_library_service_client_v1.py


### PR DESCRIPTION
gapic-generator:
- feat: add the last segment when generating names for singleton resoures
- fix: add null check and better error message when referenced resources are not found
- feat: Support extra plugin_args for php bazel rules rules (#3165)
- feat: support '*' in resource definition (#3163)
- fix: align text in license (#3158)
- fix(python): add PROJECT_ID for python-system-test (#3161)
- fix(PYTHON): update nox file and modernize to new interface (#3156)

resource name plugin
- feat: add the last segment when generating names for singleton resources
- feat: support * annotation in resource def (#84) 
- feat: trace up only one level when calculating parent types with singleton resources
- fix: stop generating `parseList` and `toStringList` if a multi-pattern resource class has subclasses

also whitelist Asset to unblock releasing artman.